### PR TITLE
Add serve deno command and update api to serve frontend routes

### DIFF
--- a/apps/webapp/Dockerfile
+++ b/apps/webapp/Dockerfile
@@ -1,0 +1,17 @@
+FROM denoland/deno:2.1.1
+
+EXPOSE 8000
+
+WORKDIR /app
+
+# Prefer not to run as root.
+# USER deno
+
+# These steps will be re-run upon each file change in your working directory:
+COPY . .
+RUN deno install
+
+# Compile the main app so that it doesn't need to be compiled each startup/entry.
+# RUN deno cache main.ts
+
+CMD ["task", "serve"]

--- a/apps/webapp/api/main.ts
+++ b/apps/webapp/api/main.ts
@@ -3,6 +3,8 @@ import { cors } from "@hono/hono/cors";
 import { logger } from "@hono/hono/logger";
 import { poweredBy } from "@hono/hono/powered-by";
 import { extract } from '@extractus/article-extractor';
+import { serveStatic } from "@hono/hono/serve-static";
+import { trimTrailingSlash } from '@hono/hono/trailing-slash'
 
 const app = new Hono();
 
@@ -18,11 +20,14 @@ app.use(
     credentials: true,
   })
 );
-app.get("/", (c: Context) => {
+
+app.use(trimTrailingSlash());
+
+app.get("/api", (c: Context) => {
   return c.text("Hello Deno!");
 });
 
-app.get("/parsedArticle", async (c: Context) => {
+app.get("/api/parsedArticle", async (c: Context) => {
   const url = c.req.query("url");
   if (!url) {
     c.status(400);
@@ -50,6 +55,25 @@ v1Api.post("/headline", async (c: Context) => {
   return c.json({ transformedText });
 });
 
-app.route("/v1", v1Api);
+app.route("/api/v1", v1Api);
+
+app.use("/api/*", async (c: Context) => {
+  c.status(404);
+  return c.json({ error: "Not found" });
+});
+
+// all non-api routes are served from the dist folder where
+// the Vite build output is located (react frontend)
+app.use("*", serveStatic({
+  root: "./dist",
+  getContent: async (path) => {
+    console.log("Reading file", path);
+    try {
+      return await Deno.readFile(path);
+    } catch {
+      return await Deno.readFile("dist/index.html");
+    }
+  }
+}));
 
 Deno.serve(app.fetch);

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "deno task dev:api & deno task dev:vite",
-    "dev:api": "deno run --allow-env --allow-net api/main.ts",
+    "dev:api": "deno run --allow-env --allow-net --allow-read api/main.ts",
     "dev:vite": "deno run -A npm:vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "serve": "deno task build && deno task dev:api"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.60.5",

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
       "/api": {
         target: "http://localhost:8000",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
Enable production build of the wiki + api. Run using:

```
deno task serve
```

App is up and running (unprotected by HTTPS and on some randomly generated domain at a port)
http://i8kww8kk00oogcg0cc88kkkc.5.78.111.152.sslip.io:8001/

This is just a proof of concept for hosting. We should determine a cloud provider we're comfortable with using.

Also deployed using Render: https://trust-assembly-anil.onrender.com/

Closes issue #6 