### PR TITLE
POC: Show headline modification from coolify backend

### DIFF
--- a/apps/browser-extension/configs/config.test.ts
+++ b/apps/browser-extension/configs/config.test.ts
@@ -1,0 +1,6 @@
+import { BACKEND_URL, API_VERSION } from '../src/utils/constants';
+
+export const CONFIG = {
+  BACKEND_URL: BACKEND_URL.TEST,
+  API_VERSION: API_VERSION.V1,
+};

--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Alerts you of limbic hijacking via transformed media headlines",
   "permissions": ["storage", "activeTab", "scripting", "tabs"],
-  "host_permissions": ["https://trust-assembly.org/*"],
+  "host_permissions": ["http://i8kww8kk00oogcg0cc88kkkc.5.78.111.152.sslip.io:8001/*"],
   "background": {
     "service_worker": "dist/src/background.js"
   },

--- a/apps/browser-extension/popup.html
+++ b/apps/browser-extension/popup.html
@@ -13,7 +13,11 @@
   </head>
   <body>
     <h3>Headline Transformer</h3>
-    <button id="toggle-transform">Toggle Transformation</button>
+    <button id="retrieve-transform">Retrieve Transformation</button>
+    <div id="select-container" style="display: none;">
+      <select id="transform-select"></select>
+      <button id="toggle-transform">Toggle Transform</button>
+    </div>
 
     <script src="dist/src/popup.js"></script>
   </body>

--- a/apps/browser-extension/src/api/backendApi.ts
+++ b/apps/browser-extension/src/api/backendApi.ts
@@ -1,6 +1,6 @@
 // TODO: make this dynamic based on which environment we're in, for now it's
 // hardcoded to only work locally
-import { CONFIG } from '../../configs/config.local';
+import { CONFIG } from '../../configs/config.test';
 import { TransformedArticle } from '../models/TransformedArticle';
 import { getBackendUrlFromEnvironmentAndVersion } from '../utils/constants';
 

--- a/apps/browser-extension/src/api/backendApi.ts
+++ b/apps/browser-extension/src/api/backendApi.ts
@@ -1,18 +1,19 @@
 // TODO: make this dynamic based on which environment we're in, for now it's
 // hardcoded to only work locally
 import { CONFIG } from '../../configs/config.local';
-import { Article } from '../models/Article';
 import { TransformedArticle } from '../models/TransformedArticle';
 import { getBackendUrlFromEnvironmentAndVersion } from '../utils/constants';
 
-export async function getTransformation(
-  article: Article,
-): Promise<TransformedArticle> {
+export async function getTransformations(
+  url: string,
+): Promise<TransformedArticle[] | undefined> {
   try {
-    const result = await makeRequest<TransformedArticle>(
+    const result = await makeRequest<TransformedArticle[]>(
       'POST',
-      '/headline',
-      article,
+      '/headlines',
+      {
+        url,
+      },
     );
 
     console.log(`background::sendResponse: ${JSON.stringify(result, null, 2)}`);

--- a/apps/browser-extension/src/api/dummyApi.ts
+++ b/apps/browser-extension/src/api/dummyApi.ts
@@ -1,8 +1,8 @@
-import { Article } from '../models/Article';
-import { TransformedArticle } from '../models/TransformedArticle';
+// import { Article } from '../models/Article';
+// import { TransformedArticle } from '../models/TransformedArticle';
 
-export async function dummyGetTransformation(
-  article: Article,
-): Promise<TransformedArticle> {
-  return Promise.resolve({ transformedText: article.headline.toUpperCase() });
-}
+// export async function dummyGetTransformation(
+//   article: Article,
+// ): Promise<TransformedArticle> {
+//   return Promise.resolve({ transformedText: article.headline.toUpperCase() });
+// }

--- a/apps/browser-extension/src/background.ts
+++ b/apps/browser-extension/src/background.ts
@@ -1,5 +1,5 @@
 import { TrustAssemblyMessage } from './utils/messagePassing';
-import { getTransformation } from './api/backendApi';
+import { getTransformations } from './api/backendApi';
 import { MessagePayload } from './models/MessagePayload';
 
 console.log(
@@ -27,7 +27,7 @@ chrome.runtime.onMessage.addListener(
 
       // Make the API request to your backend
       try {
-        const transformedArticle = await getTransformation(message.article);
+        const transformedArticle = await getTransformations(message.url);
         sendResponse(transformedArticle);
       } catch (error) {
         console.error('Error fetching transformed headline:', error);

--- a/apps/browser-extension/src/contentScript.ts
+++ b/apps/browser-extension/src/contentScript.ts
@@ -1,7 +1,4 @@
-import { dummyGetTransformation } from './api/dummyApi';
-import { Article } from './models/Article';
 import { MessagePayload } from './models/MessagePayload';
-import { TransformedArticle } from './models/TransformedArticle';
 import ArticleStateManager from './utils/ArticleStateManager';
 import { TrustAssemblyMessage } from './utils/messagePassing';
 
@@ -31,38 +28,8 @@ function findHeadlineElement() {
   console.log('Headline element not found on this page.');
 }
 
-const requestTransformedHeadline = async (
-  article: Article,
-): Promise<TransformedArticle> => {
-  // just use the dummy API for now
-  return await dummyGetTransformation(article);
-
-  // TODO: uncomment this code below so that we actually communite with the backend
-  // rather than just returning the original text uppercase. Right now @melvillian
-  // commented this out to make the PR easier to work with; the plan is to
-  // add backend communication to the extension and then uncomment this code.
-
-  // const response = await chrome.runtime.sendMessage<
-  //   MessagePayload,
-  //   TransformedArticle | undefined
-  // >({
-  //   action: TrustAssemblyMessage.FETCH_TRANSFORMED_HEADLINE,
-  //   article,
-  // });
-  // console.log('chrome.runtime.sendMessage');
-  // console.log(`response: ${response}`);
-  // if (chrome.runtime.lastError) {
-  //   console.error(chrome.runtime.lastError);
-  //   throw new Error(chrome.runtime.lastError.message);
-  // } else if (response && response.transformedText) {
-  //   console.log('resolve(response);');
-  //   return response;
-  // } else {
-  //   throw new Error('No transformed text received');
-  // }
-};
-
-const stateManager = new ArticleStateManager(requestTransformedHeadline);
+const stateManager = new ArticleStateManager();
+let modifiedHeadline: string | undefined;
 
 (async function () {
   const elementToModify = findHeadlineElement();
@@ -71,7 +38,7 @@ const stateManager = new ArticleStateManager(requestTransformedHeadline);
   await stateManager.setElement(elementToModify);
 
   elementToModify.addEventListener('click', () =>
-    stateManager.toggleModification(),
+    stateManager.toggleModification(modifiedHeadline),
   );
 
   chrome.runtime.onMessage.addListener(
@@ -79,11 +46,10 @@ const stateManager = new ArticleStateManager(requestTransformedHeadline);
       console.log('Got message:', message);
 
       if (message.action === TrustAssemblyMessage.TOGGLE_MODIFICATION) {
-        stateManager.toggleModification();
+        modifiedHeadline = message.headline;
+        stateManager.toggleModification(modifiedHeadline);
         return false;
       }
     },
   );
-
-  stateManager.toggleModification();
 })();

--- a/apps/browser-extension/src/models/Article.ts
+++ b/apps/browser-extension/src/models/Article.ts
@@ -1,3 +1,3 @@
 export type Article = {
-  headline: string;
+  url: string;
 };

--- a/apps/browser-extension/src/models/MessagePayload.ts
+++ b/apps/browser-extension/src/models/MessagePayload.ts
@@ -1,11 +1,11 @@
 import { TrustAssemblyMessage } from '../utils/messagePassing';
-import { Article } from './Article';
 
 export type MessagePayload =
   | {
       action: TrustAssemblyMessage.TOGGLE_MODIFICATION;
+      headline?: string;
     }
   | {
       action: TrustAssemblyMessage.FETCH_TRANSFORMED_HEADLINE;
-      article: Article;
+      url: string;
     };

--- a/apps/browser-extension/src/models/TransformedArticle.ts
+++ b/apps/browser-extension/src/models/TransformedArticle.ts
@@ -1,4 +1,5 @@
 // this should probably just be an Article
 export type TransformedArticle = {
-  transformedText: string;
+  headline: string;
+  creator: string;
 };

--- a/apps/browser-extension/src/popup.ts
+++ b/apps/browser-extension/src/popup.ts
@@ -1,14 +1,85 @@
+import { getTransformations } from './api/backendApi';
+import { MessagePayload } from './models/MessagePayload';
+import { TransformedArticle } from './models/TransformedArticle';
 import { TrustAssemblyMessage } from './utils/messagePassing';
 
-const transformButton = document.getElementById('toggle-transform');
-transformButton?.addEventListener('click', async () => {
+let currentUrl: string | undefined = undefined;
+chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+  const urlString = tabs[0].url;
+  if (!urlString) {
+    return;
+  }
+
+  const url = new URL(urlString);
+  currentUrl = url.origin + url.pathname;
+});
+
+let selectedHeadline: string | undefined;
+
+const retrieveButton = document.getElementById('retrieve-transform');
+retrieveButton?.addEventListener('click', async () => {
+  if (!currentUrl) {
+    console.warn('No current URL found');
+    return;
+  }
+
+  const data = await getHeadlineData(currentUrl);
+  if (data) {
+    retrieveButton!.style.display = 'none';
+    setupCreatorSelector(data);
+  }
+});
+
+const toggleButton = document.getElementById('toggle-transform');
+toggleButton?.addEventListener('click', async () => {
   const [tab] = await chrome.tabs.query({
     active: true,
     lastFocusedWindow: true,
   });
   if (tab?.id) {
-    chrome.tabs.sendMessage(tab.id, {
+    chrome.tabs.sendMessage<MessagePayload>(tab.id, {
       action: TrustAssemblyMessage.TOGGLE_MODIFICATION,
+      headline: selectedHeadline,
     });
   }
 });
+
+const STORED_DATA = 'storedHeadlineData';
+
+async function getHeadlineData(
+  url: string,
+): Promise<TransformedArticle[] | undefined> {
+  const storedData = sessionStorage.getItem(STORED_DATA);
+  if (storedData) {
+    return JSON.parse(storedData) as TransformedArticle[];
+  }
+
+  const data = await getTransformations(url);
+  if (data) {
+    sessionStorage.setItem(STORED_DATA, JSON.stringify(data));
+  }
+  return data;
+}
+
+function setupCreatorSelector(data: TransformedArticle[]) {
+  document.getElementById('select-container')!.style.display = 'block';
+
+  const select = document.getElementById(
+    'transform-select',
+  ) as HTMLSelectElement;
+  select.innerHTML = '';
+  data.forEach((article, index) => {
+    const option = document.createElement('option');
+    option.value = article.headline;
+    option.textContent = article.creator;
+    if (index === 0) {
+      option.selected = true;
+      selectedHeadline = article.headline;
+    }
+    select.appendChild(option);
+  });
+
+  select.addEventListener('change', (event) => {
+    selectedHeadline = (event.target as HTMLSelectElement).value;
+  });
+}

--- a/apps/browser-extension/src/utils/ArticleStateManager.ts
+++ b/apps/browser-extension/src/utils/ArticleStateManager.ts
@@ -1,12 +1,9 @@
-import { Article } from '../models/Article';
-import { TransformedArticle } from '../models/TransformedArticle';
-
 export type ArticleElement = {
   style: {
     color: string;
     fontStyle: string;
   };
-  article: Article;
+  headline: string;
 };
 
 const MODIFIED_STYLE = {
@@ -24,12 +21,6 @@ export default class ArticleStateManager {
   private originalProps: ArticleElement | null = null;
   private modifiedProps: ArticleElement | null = null;
 
-  constructor(
-    private fetchModification: (
-      article: Article,
-    ) => Promise<TransformedArticle>,
-  ) {}
-
   public async setElement(element: HTMLElement): Promise<void> {
     console.log('setting element:', element);
 
@@ -39,36 +30,24 @@ export default class ArticleStateManager {
         color: element.style.color,
         fontStyle: element.style.fontStyle,
       },
-      article: {
-        headline: element.textContent || '',
-      },
-    };
-
-    const modifiedArticle = await this.fetchModification(
-      this.originalProps.article,
-    );
-    this.modifiedProps = {
-      style: MODIFIED_STYLE,
-      article: {
-        headline: modifiedArticle.transformedText,
-      },
+      headline: element.textContent || '',
     };
   }
 
-  public toggleModification(): void {
+  public toggleModification(modifiedHeadline?: string): void {
     if (!this.element || !this.originalProps) {
       console.warn('No element to modify');
       return;
     }
-    if (!this.modifiedProps) {
-      console.warn('No modified headline to apply');
-      return;
-    }
+    this.modifiedProps = {
+      style: MODIFIED_STYLE,
+      headline: modifiedHeadline || this.originalProps.headline,
+    };
 
     this.toggleState = !this.toggleState;
     const {
       style: { color, fontStyle },
-      article: { headline },
+      headline,
     } = this.toggleState ? this.modifiedProps : this.originalProps;
 
     console.log(`element.style.color: ${color}`);

--- a/apps/browser-extension/src/utils/constants.ts
+++ b/apps/browser-extension/src/utils/constants.ts
@@ -3,7 +3,7 @@ export enum BACKEND_URL {
   PROD = 'https://trust-assembly.com',
   DEV = 'https://dev.trust-assembly.com',
   STAGING = 'https://staging.trust-assembly.com',
-  TEST = 'https://test.trust-assembly.com',
+  TEST = 'http://i8kww8kk00oogcg0cc88kkkc.5.78.111.152.sslip.io:8001',
 }
 
 export enum API_VERSION {

--- a/apps/browser-extension/src/utils/constants.ts
+++ b/apps/browser-extension/src/utils/constants.ts
@@ -1,5 +1,5 @@
 export enum BACKEND_URL {
-  LOCAL = 'http://localhost:8000',
+  LOCAL = 'http://localhost:5173',
   PROD = 'https://trust-assembly.com',
   DEV = 'https://dev.trust-assembly.com',
   STAGING = 'https://staging.trust-assembly.com',

--- a/apps/webapp/api/fakeDb.ts
+++ b/apps/webapp/api/fakeDb.ts
@@ -1,0 +1,24 @@
+const fakeData = [
+  {
+    url: "https://www.cnn.com/2024/12/05/politics/john-roberts-transgender-skrmetti-analysis",
+    headline: "John Roberts headline from ACX",
+    creator: "Scott Alexander",
+  },
+  {
+    url: "https://www.cnn.com/2024/12/05/politics/pete-hegseth-private-turmoil-invs",
+    headline: "Pete Hegseth headline from ACX",
+    creator: "Scott Alexander",
+  },
+  {
+    url: "https://www.cnn.com/2024/12/05/politics/john-roberts-transgender-skrmetti-analysis",
+    headline: "John Roberts headline from Extelligence",
+    creator: "Some Guy",
+  },
+  {
+    url: "https://www.cnn.com/2024/12/05/entertainment/macaulay-culkin-son-home-alone",
+    headline: "Disregard this article (from Extelligence)",
+    creator: "Some Guy",
+  }
+ ] as const;
+
+export default fakeData;


### PR DESCRIPTION
Simple display of retrieving modified headlines from the API. The API currently just has dummy data associated with a couple of articles (see API source code).

Demo:

https://github.com/user-attachments/assets/aa074684-181e-40d1-b566-dbf529372d6c

To try this for yourself, pull the branch and build the extension. Run `npm run build` in the `browser-extension` directory and load the extension in your browser. Go to any of
- https://www.cnn.com/2024/12/05/politics/john-roberts-transgender-skrmetti-analysis
- https://www.cnn.com/2024/12/05/entertainment/macaulay-culkin-son-home-alone
- https://www.cnn.com/2024/12/05/politics/pete-hegseth-private-turmoil-invs

and click through the buttons