### PR TITLE
Remove seed container for deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,3 @@ services:
       args:
         POSTGRES_HOST: ${POSTGRES_HOST}
     command: deno run -A https://deno.land/x/nessie/cli.ts migrate
-  seed:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-      target: migrator
-      args:
-        POSTGRES_HOST: ${POSTGRES_HOST}
-    command: deno run -A https://deno.land/x/nessie/cli.ts seed
-    depends_on:
-      - migrate


### PR DESCRIPTION
Noticed the seed container is running periodically on coolify and causing errors. This removes the container from the deployment config