### PR TITLE
Add session management

### DIFF
--- a/apps/webapp/api/basicDbRepo.ts
+++ b/apps/webapp/api/basicDbRepo.ts
@@ -10,6 +10,7 @@ export default class BasicDbRepo {
       hostname: Deno.env.get("POSTGRES_HOST"),
       port: 5432,
       password: Deno.env.get("POSTGRES_PASSWORD"),
+      
     });
     await client.connect();
     return new BasicDbRepo(client);

--- a/apps/webapp/deno.json
+++ b/apps/webapp/deno.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@^4.7.1"
+    "@hono/hono": "jsr:@hono/hono@^4.7.1",
+    "@jcs224/hono-sessions": "jsr:@jcs224/hono-sessions@^0.7.2"
   }
 }

--- a/apps/webapp/deno.lock
+++ b/apps/webapp/deno.lock
@@ -1,10 +1,11 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@hono/hono@^4.6.10": "4.6.10",
+    "jsr:@hono/hono@^4.7.1": "4.7.10",
+    "jsr:@jcs224/hono-sessions@*": "0.7.2",
     "npm:@eslint/js@^9.13.0": "9.15.0",
-    "npm:@tanstack/react-query@^5.60.5": "5.60.5_react@18.3.1",
     "npm:@extractus/article-extractor@^8.0.16": "8.0.16",
+    "npm:@tanstack/react-query@^5.60.5": "5.60.5_react@18.3.1",
     "npm:@types/react-dom@^18.3.1": "18.3.1",
     "npm:@types/react@^18.3.12": "18.3.12",
     "npm:@vitejs/plugin-react@^4.3.3": "4.3.3_vite@5.4.11_@babel+core@7.26.0",
@@ -21,8 +22,11 @@
     "npm:vite@^5.4.10": "5.4.11"
   },
   "jsr": {
-    "@hono/hono@4.6.10": {
-      "integrity": "dae93ac8bb49881f99506aa8e01e5536d5d72cc3c2b556bde2816fdf25ca609c"
+    "@hono/hono@4.7.10": {
+      "integrity": "e59029e252af371abe43e8e4f9a115e38974c6bd5972022372bf89f763269cc7"
+    },
+    "@jcs224/hono-sessions@0.7.2": {
+      "integrity": "d68311491b514e0947495de4bd0b0542b3f299bc25acdf30c2e0f953d71ab58a"
     }
   },
   "npm": {
@@ -1403,6 +1407,7 @@
     "https://deno.land/std@0.214.0/fmt/colors.ts": "aeaee795471b56fc62a3cb2e174ed33e91551b535f44677f6320336aabb54fbb",
     "https://deno.land/std@0.214.0/io/buf_reader.ts": "c73aad99491ee6db3d6b001fa4a780e9245c67b9296f5bad9c0fa7384e35d47a",
     "https://deno.land/std@0.214.0/io/buf_writer.ts": "f82f640c8b3a820f600a8da429ad0537037c7d6a78426bbca2396fb1f75d3ef4",
+    "https://deno.land/std@0.214.0/io/types.ts": "748bbb3ac96abda03594ef5a0db15ce5450dcc6c0d841c8906f8b10ac8d32c96",
     "https://deno.land/std@0.214.0/path/_common/assert_path.ts": "2ca275f36ac1788b2acb60fb2b79cb06027198bc2ba6fb7e163efaedde98c297",
     "https://deno.land/std@0.214.0/path/_common/basename.ts": "569744855bc8445f3a56087fd2aed56bdad39da971a8d92b138c9913aecc5fa2",
     "https://deno.land/std@0.214.0/path/_common/common.ts": "6157c7ec1f4db2b4a9a187efd6ce76dcaf1e61cfd49f87e40d4ea102818df031",
@@ -1503,18 +1508,20 @@
     "https://deno.land/x/postgres@v0.19.3/query/oid.ts": "21fc714ac212350ba7df496f88ea9e01a4ee0458911d0f2b6a81498e12e7af4c",
     "https://deno.land/x/postgres@v0.19.3/query/query.ts": "510f9a27da87ed7b31b5cbcd14bf3028b441ac2ddc368483679d0b86a9d9f213",
     "https://deno.land/x/postgres@v0.19.3/query/transaction.ts": "8f4eef68f8e9b4be216199404315e6e08fe1fe98afb2e640bffd077662f79678",
+    "https://deno.land/x/postgres@v0.19.3/query/types.ts": "540f6f973d493d63f2c0059a09f3368071f57931bba68bea408a635a3e0565d6",
     "https://deno.land/x/postgres@v0.19.3/utils/deferred.ts": "5420531adb6c3ea29ca8aac57b9b59bd3e4b9a938a4996bbd0947a858f611080",
     "https://deno.land/x/postgres@v0.19.3/utils/utils.ts": "ca47193ea03ff5b585e487a06f106d367e509263a960b787197ce0c03113a738"
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@^4.6.10"
+      "jsr:@hono/hono@^4.7.1",
+      "jsr:@jcs224/hono-sessions@~0.7.2"
     ],
     "packageJson": {
       "dependencies": [
         "npm:@eslint/js@^9.13.0",
-        "npm:@tanstack/react-query@^5.60.5",
         "npm:@extractus/article-extractor@^8.0.16",
+        "npm:@tanstack/react-query@^5.60.5",
         "npm:@types/react-dom@^18.3.1",
         "npm:@types/react@^18.3.12",
         "npm:@vitejs/plugin-react@^4.3.3",

--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -5,6 +5,7 @@ import './App.css'
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import QueryBoundaryProvider from "./contexts/QueryBoundaryProvider";
 import ParsedArticle from "./ParsedArticle";
+import SessionProvider from "./contexts/SessionProvider";
 
 function App() {
   const queryClient = new QueryClient({
@@ -18,13 +19,15 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <QueryBoundaryProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/hello" element={<Hello />} />
-            <Route path="/parsedArticle" element={<ParsedArticle />} />
-          </Routes>
-        </BrowserRouter>
+        <SessionProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/hello" element={<Hello />} />
+              <Route path="/parsedArticle" element={<ParsedArticle />} />
+            </Routes>
+          </BrowserRouter>
+        </SessionProvider>
       </QueryBoundaryProvider>
     </QueryClientProvider>
   )

--- a/apps/webapp/src/Hello.tsx
+++ b/apps/webapp/src/Hello.tsx
@@ -1,15 +1,20 @@
-import { getHello } from "./backend/api";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSession } from "./contexts/SessionProvider";
 
+// Test component for features in development
 export default function Hello() {
-  const { data: message } = useSuspenseQuery({
-    queryKey: ["hello"],
-    queryFn: getHello,
-  });
+  const session = useSession();
 
   return (
     <div>
-      <h1>{message}</h1>
+      {session.type === "loggedIn" ? (
+        <h1>Hello, {session.user.name}!</h1>
+      ) : (
+        <button
+          onClick={session.login}
+        >
+          Login
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/webapp/src/backend/api.ts
+++ b/apps/webapp/src/backend/api.ts
@@ -11,6 +11,26 @@ export async function getParsedArticle(url: string): Promise<ArticleData | null>
   return await response.json();
 }
 
+export type User = {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export async function getUser(): Promise<User | null> {
+  const response = await makeRequest('GET', '/api/user');
+  if (response.status === 401) {
+    return null;
+  }
+  return await response.json();
+}
+
+// dummy login for now. Will need to integrate with google auth
+export async function login(): Promise<User> {
+  const response = await makeRequest('POST', '/api/login');
+  return await response.json();
+}
+
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
 function makeRequest(method: HttpMethod, url: string, data?: any): Promise<Response> {

--- a/apps/webapp/src/contexts/SessionProvider.tsx
+++ b/apps/webapp/src/contexts/SessionProvider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { getUser, login, User } from "../backend/api";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+
+export type Session = {
+  type: "loggedIn";
+  user: User;
+} | {
+  type: "loggedOut";
+  login: () => void;
+};
+
+export const SessionContext = createContext<Session | null>(null);
+
+export const useSession = () => {
+  const value = useContext(SessionContext);
+  if (value === null) {
+    throw new Error("useSession must be used within a SessionProvider");
+  }
+  return value;
+}
+
+type Props = {
+  children: React.ReactNode;
+}
+export default function SessionProvider({ children }: Props) {
+  const queryClient = useQueryClient();
+  const { data: user } = useSuspenseQuery({
+    queryKey: ["user"],
+    queryFn: getUser,
+  });
+  const loginMutator = useMutation({
+    mutationFn: login,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user"] });
+    },
+  })
+
+  const session: Session = user
+    ? { type: "loggedIn", user }
+    : { type: "loggedOut", login: () => loginMutator.mutate() };
+  
+  return (
+    <SessionContext.Provider value={session}>
+      {children}
+    </SessionContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

- Use`hono-sessions` to manage user sessions on the backend
- Add a simple React context to allow descendant components to access user sessions

The session is stored in the browser cookie. Any requests to the API that require the user to be logged in will need to include cookies in the request (using [fetch credentials include](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials)). Right now logging in will just add a dummy user to the session. Will follow up to integrate this with Google sign in and the `users` table