### PR TITLE
Add google auth and token verification

### DIFF
--- a/apps/webapp/api/auth.ts
+++ b/apps/webapp/api/auth.ts
@@ -1,0 +1,64 @@
+import * as jose from "jsr:@panva/jose";
+
+export class JwtDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JwtDecodeError";
+  }
+}
+
+export class JwtVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JwtVerificationError";
+  }
+}
+
+type JwtPayload = {
+  iss: string; // Issuer
+  sub: string; // Subject
+  aud: string; // Audience
+  exp: number; // Expiration time
+  iat: number; // Issued at time
+  name: string;
+  email: string;
+};
+
+export async function authenticateToken(token: string): Promise<JwtPayload> {
+  const payload = decodeToken(token);
+
+  const jwksUrl = getJwksUrl(payload.iss);
+  try {
+    const jwks = jose.createRemoteJWKSet(new URL(jwksUrl));
+    const {
+      payload: verifiedPayload,
+    } = await jose.jwtVerify(token, jwks, {
+      issuer: payload.iss,
+      audience: payload.aud,
+    });
+  
+    return verifiedPayload;
+  } catch (e) {
+    console.log("Error verifying JWT:", e);
+    const error = e instanceof Error ? e : new Error(String(e));
+    throw new JwtVerificationError(error.message);
+  }
+}
+
+function decodeToken(token: string): JwtPayload {
+  try {
+    return jose.decodeJwt(token);
+  } catch (e) {
+    console.log("Error decoding JWT:", e);
+    const error = e instanceof Error ? e : new Error(String(e));
+    throw new JwtDecodeError(error.message);
+  }
+}
+
+function getJwksUrl(issuer: string): string {
+  if (issuer === "https://accounts.google.com") {
+    return "https://www.googleapis.com/oauth2/v3/certs";
+  }
+
+  throw new JwtVerificationError(`Unsupported issuer: ${issuer}`);
+}

--- a/apps/webapp/deno.json
+++ b/apps/webapp/deno.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "@hono/hono": "jsr:@hono/hono@^4.7.1",
-    "@jcs224/hono-sessions": "jsr:@jcs224/hono-sessions@^0.7.2"
+    "@jcs224/hono-sessions": "jsr:@jcs224/hono-sessions@^0.7.2",
+    "@panva/jose": "jsr:@panva/jose@6.0.11"
   }
 }

--- a/apps/webapp/deno.lock
+++ b/apps/webapp/deno.lock
@@ -3,8 +3,11 @@
   "specifiers": {
     "jsr:@hono/hono@^4.7.1": "4.7.10",
     "jsr:@jcs224/hono-sessions@*": "0.7.2",
+    "jsr:@jcs224/hono-sessions@~0.7.2": "0.7.2",
+    "jsr:@panva/jose@6.0.11": "6.0.11",
     "npm:@eslint/js@^9.13.0": "9.15.0",
     "npm:@extractus/article-extractor@^8.0.16": "8.0.16",
+    "npm:@react-oauth/google@~0.12.2": "0.12.2_react@18.3.1_react-dom@18.3.1__react@18.3.1",
     "npm:@tanstack/react-query@^5.60.5": "5.60.5_react@18.3.1",
     "npm:@types/react-dom@^18.3.1": "18.3.1",
     "npm:@types/react@^18.3.12": "18.3.12",
@@ -13,6 +16,8 @@
     "npm:eslint-plugin-react-refresh@~0.4.14": "0.4.14_eslint@9.15.0",
     "npm:eslint@^9.13.0": "9.15.0",
     "npm:globals@^15.11.0": "15.12.0",
+    "npm:hono@4": "4.7.10",
+    "npm:iron-webcrypto@^1.2.1": "1.2.1",
     "npm:react-dom@^18.3.1": "18.3.1_react@18.3.1",
     "npm:react-error-boundary@^4.1.2": "4.1.2_react@18.3.1",
     "npm:react-router-dom@^6.28.0": "6.28.0_react@18.3.1_react-dom@18.3.1__react@18.3.1",
@@ -26,7 +31,14 @@
       "integrity": "e59029e252af371abe43e8e4f9a115e38974c6bd5972022372bf89f763269cc7"
     },
     "@jcs224/hono-sessions@0.7.2": {
-      "integrity": "d68311491b514e0947495de4bd0b0542b3f299bc25acdf30c2e0f953d71ab58a"
+      "integrity": "d68311491b514e0947495de4bd0b0542b3f299bc25acdf30c2e0f953d71ab58a",
+      "dependencies": [
+        "npm:hono",
+        "npm:iron-webcrypto"
+      ]
+    },
+    "@panva/jose@6.0.11": {
+      "integrity": "90d3a31fbe29ab3ab64f5c8c7c413b8a962663d7c62eacd51cc7f41d9c42ccbf"
     }
   },
   "npm": {
@@ -363,6 +375,13 @@
       "dependencies": [
         "@nodelib/fs.scandir",
         "fastq"
+      ]
+    },
+    "@react-oauth/google@0.12.2_react@18.3.1_react-dom@18.3.1__react@18.3.1": {
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "dependencies": [
+        "react",
+        "react-dom"
       ]
     },
     "@remix-run/router@1.21.0": {
@@ -949,6 +968,9 @@
     "has-flag@4.0.0": {
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
+    "hono@4.7.10": {
+      "integrity": "sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ=="
+    },
     "html-escaper@3.0.3": {
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
@@ -982,6 +1004,9 @@
     },
     "imurmurhash@0.1.4": {
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+    },
+    "iron-webcrypto@1.2.1": {
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="
     },
     "is-extglob@2.1.1": {
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
@@ -1515,12 +1540,14 @@
   "workspace": {
     "dependencies": [
       "jsr:@hono/hono@^4.7.1",
-      "jsr:@jcs224/hono-sessions@~0.7.2"
+      "jsr:@jcs224/hono-sessions@~0.7.2",
+      "jsr:@panva/jose@6.0.11"
     ],
     "packageJson": {
       "dependencies": [
         "npm:@eslint/js@^9.13.0",
         "npm:@extractus/article-extractor@^8.0.16",
+        "npm:@react-oauth/google@~0.12.2",
         "npm:@tanstack/react-query@^5.60.5",
         "npm:@types/react-dom@^18.3.1",
         "npm:@types/react@^18.3.12",

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -13,6 +13,7 @@
     "serve": "deno task build && deno task dev:api"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.2",
     "@tanstack/react-query": "^5.60.5",
     "@extractus/article-extractor": "^8.0.16",
     "react": "^18.3.1",

--- a/apps/webapp/src/Hello.tsx
+++ b/apps/webapp/src/Hello.tsx
@@ -1,3 +1,4 @@
+import { GoogleLogin, GoogleOAuthProvider } from "@react-oauth/google";
 import { useSession } from "./contexts/SessionProvider";
 
 // Test component for features in development
@@ -5,16 +6,22 @@ export default function Hello() {
   const session = useSession();
 
   return (
-    <div>
-      {session.type === "loggedIn" ? (
-        <h1>Hello, {session.user.name}!</h1>
-      ) : (
-        <button
-          onClick={session.login}
-        >
-          Login
-        </button>
-      )}
-    </div>
+    // TODO: move clientId to env variable
+    <GoogleOAuthProvider clientId={"866724834732-5qma1gh7ns35hqg92oamrqgjlq8dbt77.apps.googleusercontent.com"}>
+      <div>
+        {session.type === "loggedIn" ? (
+          <h1>Hello, {session.user.name}!</h1>
+        ) : (
+          <GoogleLogin
+            onSuccess={credentialResponse => {
+              session.login(credentialResponse.credential!);
+            }}
+            onError={() => {
+              console.log('Login Failed');
+            }}
+          />
+        )}
+      </div>
+    </GoogleOAuthProvider>
   )
 }

--- a/apps/webapp/src/backend/api.ts
+++ b/apps/webapp/src/backend/api.ts
@@ -25,9 +25,12 @@ export async function getUser(): Promise<User | null> {
   return await response.json();
 }
 
-// dummy login for now. Will need to integrate with google auth
-export async function login(): Promise<User> {
-  const response = await makeRequest('POST', '/api/login');
+export async function login(token: string): Promise<User> {
+  const response = await makeRequest(
+    'POST',
+    '/api/login',
+    { token }
+  );
   return await response.json();
 }
 

--- a/apps/webapp/src/contexts/SessionProvider.tsx
+++ b/apps/webapp/src/contexts/SessionProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext } from "react";
 import { getUser, login, User } from "../backend/api";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
@@ -7,7 +7,7 @@ export type Session = {
   user: User;
 } | {
   type: "loggedOut";
-  login: () => void;
+  login: (token: string) => void;
 };
 
 export const SessionContext = createContext<Session | null>(null);
@@ -38,7 +38,7 @@ export default function SessionProvider({ children }: Props) {
 
   const session: Session = user
     ? { type: "loggedIn", user }
-    : { type: "loggedOut", login: () => loginMutator.mutate() };
+    : { type: "loggedOut", login: (token) => loginMutator.mutate(token) };
   
   return (
     <SessionContext.Provider value={session}>


### PR DESCRIPTION
## Summary

Add google authentication button on the `/hello` page for demo purposes. This uses [Google One Tap Login](https://developers.google.com/identity/gsi/web/guides/display-google-one-tap) via the [react-oauth](https://www.npmjs.com/package/@react-oauth/google) package. The frontend will make a POST request to the API with the token, then the backend will validate the JWT and set the session.

### Demo

On the `/hello` page:

https://github.com/user-attachments/assets/be01d609-0cc7-4847-aad8-1bf120341796

### Next steps

- Hook this up to the login button on the navbar
- Create the `users` and `user_identity_providers` tables and retrieve the user from those instead of using the Google JWT for user information