### PR TITLE
Add AuthPage for protected UI routes

### DIFF
--- a/apps/webapp/src/Replacements.tsx
+++ b/apps/webapp/src/Replacements.tsx
@@ -1,8 +1,8 @@
 import { Fragment } from "react/jsx-runtime";
-import Page from "./components/Page";
 import Card from "./components/Card";
 import { getReplacementHeadlines, Replacement } from "./backend/api";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import AuthPage from "./components/AuthPage";
 
 type ReplacementItemProps = {
   replacement: Replacement,
@@ -108,7 +108,7 @@ export default function Replacements() {
   });
 
   return (
-    <Page>
+    <AuthPage>
       <h1 className="text-2xl text-center">Headline Replacements</h1>
       <div className="mt-6 gap-8 flex flex-col sm:px-2 lg:px-10 mb-8">
         {replacementHeadlines.map((replacement) => (
@@ -117,6 +117,6 @@ export default function Replacements() {
           </Fragment>
         ))}
       </div>
-    </Page>
+    </AuthPage>
   );
 }

--- a/apps/webapp/src/components/AuthPage.tsx
+++ b/apps/webapp/src/components/AuthPage.tsx
@@ -1,0 +1,15 @@
+import { useSession } from "@/contexts/SessionProvider"
+import Page from "./Page";
+
+type AuthPageProps = {
+  children?: React.ReactNode;
+};
+export default function AuthPage({ children }: AuthPageProps) {
+  const session = useSession();
+
+  if (session.type === 'loggedIn') {
+    return <Page>{children}</Page>;
+  }
+
+  return <Page signInOpen={true} />;
+}

--- a/apps/webapp/src/components/Navbar.tsx
+++ b/apps/webapp/src/components/Navbar.tsx
@@ -6,11 +6,13 @@ import LoginButton from "./LoginButton";
 
 // built from the tailwind example https://tailwindcss.com/plus/ui-blocks/application-ui/navigation/navbars
 
-type NavbarProps = React.ComponentProps<'nav'>;
+type NavbarProps = React.ComponentProps<'nav'> & {
+  signInOpen?: boolean;
+};
 
 export default function Navbar(props: NavbarProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(props.signInOpen ?? false);
   const session = useSession();
 
   return (
@@ -27,10 +29,10 @@ export default function Navbar(props: NavbarProps) {
             >
               <span className="absolute -inset-0.5"></span>
               <span className="sr-only">Open main menu</span>
-              <svg className="block size-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+              <svg className="block size-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
               </svg>
-              <svg className="hidden size-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+              <svg className="hidden size-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
               </svg>
             </button>
@@ -106,7 +108,7 @@ function NavButtons({ isBlock }: NavButtonsProps) {
   return (
     <>
       <a href="#" className={className}>Home</a>
-      <a href="#" className={className}>Explore</a>
+      <a href="/replacements" className={className}>Explore</a>
       <a href="#" className={className}>About</a>
     </>
   );

--- a/apps/webapp/src/components/Page.tsx
+++ b/apps/webapp/src/components/Page.tsx
@@ -5,12 +5,13 @@ const socialMediaIcons = '/social-media-icons.jpg';
 
 type PageProps = {
   children?: React.ReactNode;
+  signInOpen?: boolean;
 };
 
-export default function Page({ children }: PageProps) {
+export default function Page({ children, signInOpen }: PageProps) {
   return (<>
     <div className="mx-auto flex flex-col max-w-7xl justify-between items-stretch px-2">
-      <Navbar />
+      <Navbar signInOpen={signInOpen} />
     </div>
     <div>
       <main>


### PR DESCRIPTION
## Summary

Creates a new `AuthPage` component to be used for pages that require login to see. This change applies this to the Replacements page

## Demo

https://github.com/user-attachments/assets/fc8d429e-1c29-46d6-afdc-4b5f66b6507d
