### PR TITLE
Add replace headline button to popup

### DIFF
--- a/apps/browser-extension/new_headline.html
+++ b/apps/browser-extension/new_headline.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Replace Headline</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        padding: 10px;
+        width: 320px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Propose New Headline</h3>
+    <form id="new-headline-form">
+      <div style="margin-top: 6px; display: flex; justify-content: space-between;">
+        <label for="nh-original">Original headline</label>
+        <div id="nh-original-count"></div>
+      </div>
+      <textarea id="nh-original" style="width: 100%; box-sizing: border-box;"></textarea>
+      <div id="nh-original-error" style="color: #dc2626; font-size: 12px; margin: 4px 0; display: none;"></div>
+
+      <div style="margin-top: 6px; display: flex; justify-content: space-between;">
+        <label for="nh-replacement">Replacement headline</label>
+        <div id="nh-replacement-count"></div>
+      </div>
+      <textarea id="nh-replacement" style="width: 100%; box-sizing: border-box;"></textarea>
+      <div id="nh-replacement-error" style="color: #dc2626; font-size: 12px; margin: 4px 0; display: none;"></div>
+
+      <section style="margin-top: 6px;">
+        <h4>Citations</h4>
+        <div id="nh-citations"></div>
+        <div id="nh-citations-error" style="color: #dc2626; font-size: 12px; margin: 4px 0; display: none;"></div>
+      </section>
+
+      <div style="display: flex; justify-content: space-between; margin-top: 8px;">
+        <button type="button" id="nh-cancel">Cancel</button>
+        <button type="submit" id="nh-submit">Save & Submit</button>
+      </div>
+    </form>
+
+    <script src="dist/src/newHeadline.js"></script>
+  </body>
+  </html>
+

--- a/apps/browser-extension/popup.html
+++ b/apps/browser-extension/popup.html
@@ -35,36 +35,6 @@
     <hr />
     <button id="replace-headline">Replace headline</button>
 
-    <div id="new-headline-view" style="display: none; margin-top: 10px;">
-      <h3>Propose New Headline</h3>
-      <form id="new-headline-form">
-        <div style="margin-top: 6px; display: flex; justify-content: space-between;">
-          <label for="nh-original">Original headline</label>
-          <div id="nh-original-count"></div>
-        </div>
-        <textarea id="nh-original" style="width: 100%; box-sizing: border-box;"></textarea>
-        <div id="nh-original-error" style="color: #dc2626; font-size: 12px; margin: 4px 0; display: none;"></div>
-
-        <div style="margin-top: 6px; display: flex; justify-content: space-between;">
-          <label for="nh-replacement">Replacement headline</label>
-          <div id="nh-replacement-count"></div>
-        </div>
-        <textarea id="nh-replacement" style="width: 100%; box-sizing: border-box;"></textarea>
-        <div id="nh-replacement-error" style="color: #dc2626; font-size: 12px; margin: 4px 0; display: none;"></div>
-
-        <section style="margin-top: 6px;">
-          <h4>Citations</h4>
-          <div id="nh-citations"></div>
-          <div id="nh-citations-error" style="color: #dc2626; font-size: 12px; margin: 4px 0; display: none;"></div>
-        </section>
-
-        <div style="display: flex; justify-content: space-between; margin-top: 8px;">
-          <button type="button" id="nh-cancel">Cancel</button>
-          <button type="submit" id="nh-submit">Save & Submit</button>
-        </div>
-      </form>
-    </div>
-
     <script src="dist/src/popup.js"></script>
   </body>
 </html>

--- a/apps/browser-extension/src/newHeadline.ts
+++ b/apps/browser-extension/src/newHeadline.ts
@@ -1,0 +1,153 @@
+// Script for new_headline.html implementing NewHeadline.tsx-like behavior
+
+const MAX_HEADLINE_LENGTH = 120;
+
+const form = document.getElementById('new-headline-form') as HTMLFormElement | null;
+const originalArea = document.getElementById('nh-original') as HTMLTextAreaElement | null;
+const replacementArea = document.getElementById('nh-replacement') as HTMLTextAreaElement | null;
+const originalCount = document.getElementById('nh-original-count');
+const replacementCount = document.getElementById('nh-replacement-count');
+const originalError = document.getElementById('nh-original-error');
+const replacementError = document.getElementById('nh-replacement-error');
+const citationsContainer = document.getElementById('nh-citations');
+const citationsError = document.getElementById('nh-citations-error');
+const cancelButton = document.getElementById('nh-cancel');
+
+type Citation = { url: string; explanation: string };
+let citations: Citation[] = [{ url: '', explanation: '' }];
+
+function renderCitations(): void {
+  if (!citationsContainer) return;
+  citationsContainer.innerHTML = '';
+  citations.forEach((citation, idx) => {
+    const wrap = document.createElement('div');
+    wrap.style.marginBottom = '8px';
+
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
+    urlInput.placeholder = 'https://...';
+    urlInput.value = citation.url;
+    urlInput.style.width = '100%';
+    urlInput.style.boxSizing = 'border-box';
+    urlInput.addEventListener('input', (e) => {
+      const value = (e.target as HTMLInputElement).value;
+      citations[idx] = { ...citations[idx], url: value };
+      if (idx === citations.length - 1 && value.trim() !== '') {
+        citations.push({ url: '', explanation: '' });
+      }
+      trimTrailingEmpty();
+      renderCitations();
+      if (citationsError) citationsError.style.display = 'none';
+    });
+    wrap.appendChild(urlInput);
+
+    const expl = document.createElement('textarea');
+    expl.placeholder = 'Optional explanation (e.g. what this citation supports)';
+    expl.value = citation.explanation;
+    expl.rows = 2;
+    expl.style.width = '100%';
+    expl.style.boxSizing = 'border-box';
+    expl.style.fontSize = '12px';
+    expl.style.marginTop = '4px';
+    expl.addEventListener('input', (e) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      citations[idx] = { ...citations[idx], explanation: value };
+    });
+    wrap.appendChild(expl);
+
+    citationsContainer.appendChild(wrap);
+  });
+}
+
+function trimTrailingEmpty(): void {
+  while (
+    citations.length > 1 &&
+    citations[citations.length - 1].url === '' &&
+    citations[citations.length - 2].url === ''
+  ) {
+    citations.pop();
+  }
+}
+
+function updateCounts(): void {
+  const o = originalArea?.value.length ?? 0;
+  const r = replacementArea?.value.length ?? 0;
+  if (originalCount) originalCount.textContent = `${o} / ${MAX_HEADLINE_LENGTH}`;
+  if (replacementCount) replacementCount.textContent = `${r} / ${MAX_HEADLINE_LENGTH}`;
+}
+
+function clearErrors(): void {
+  if (originalError) originalError.style.display = 'none';
+  if (replacementError) replacementError.style.display = 'none';
+  if (citationsError) citationsError.style.display = 'none';
+}
+
+function validate(): { originalHeadline?: string; replacementHeadline?: string; citations?: string } {
+  const errors: { originalHeadline?: string; replacementHeadline?: string; citations?: string } = {};
+  const original = originalArea?.value ?? '';
+  const replacement = replacementArea?.value ?? '';
+  if (!original.trim()) {
+    errors.originalHeadline = 'Original headline is required.';
+  } else if (original.length > MAX_HEADLINE_LENGTH) {
+    errors.originalHeadline = `Original headline must be at most ${MAX_HEADLINE_LENGTH} characters.`;
+  }
+  if (!replacement.trim()) {
+    errors.replacementHeadline = 'Replacement headline is required.';
+  } else if (replacement.length > MAX_HEADLINE_LENGTH) {
+    errors.replacementHeadline = `Replacement headline must be at most ${MAX_HEADLINE_LENGTH} characters.`;
+  }
+  const hasCitation = citations.some((c) => c.url.trim() !== '');
+  if (!hasCitation) {
+    errors.citations = 'At least one citation URL is required.';
+  }
+
+  if (originalError) {
+    originalError.textContent = errors.originalHeadline ?? '';
+    originalError.style.display = errors.originalHeadline ? 'block' : 'none';
+  }
+  if (replacementError) {
+    replacementError.textContent = errors.replacementHeadline ?? '';
+    replacementError.style.display = errors.replacementHeadline ? 'block' : 'none';
+  }
+  if (citationsError) {
+    citationsError.textContent = errors.citations ?? '';
+    citationsError.style.display = errors.citations ? 'block' : 'none';
+  }
+
+  return errors;
+}
+
+function initDefaults(): void {
+  if (originalArea) originalArea.value = 'New Study Proves Coffee Cures Cancer';
+  if (replacementArea)
+    replacementArea.value =
+      'Study Finds Correlation Between Coffee Consumption and Lower Risk of Certain Cancers';
+  citations = [{ url: '', explanation: '' }];
+  renderCitations();
+  updateCounts();
+  clearErrors();
+}
+
+// wire handlers
+originalArea?.addEventListener('input', updateCounts);
+replacementArea?.addEventListener('input', updateCounts);
+
+cancelButton?.addEventListener('click', () => {
+  window.location.href = 'popup.html';
+});
+
+form?.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const errors = validate();
+  if (Object.keys(errors).length === 0) {
+    console.log({
+      originalHeadline: originalArea?.value ?? '',
+      replacementHeadline: replacementArea?.value ?? '',
+      citations,
+    });
+  }
+});
+
+// kickoff
+initDefaults();
+

--- a/apps/browser-extension/src/popup.ts
+++ b/apps/browser-extension/src/popup.ts
@@ -8,9 +8,6 @@ let currentUrl: string | undefined = undefined;
 let selectedAuthor: string | undefined;
 let selectedHeadline: string | undefined;
 
-// constants for new-headline view
-const MAX_HEADLINE_LENGTH = 120;
-
 type ButtonDisplayState = 'none' | 'retrive' | 'toggle';
 
 // popup elements
@@ -20,22 +17,8 @@ const selectElement = document.getElementById(
   'transform-select',
 ) as HTMLSelectElement;
 
-// elements for new-headline view
+// elements for new-headline navigation
 const replaceHeadlineButton = document.getElementById('replace-headline');
-const newHeadlineView = document.getElementById('new-headline-view');
-const newHeadlineForm = document.getElementById('new-headline-form') as HTMLFormElement | null;
-const nhOriginal = document.getElementById('nh-original') as HTMLTextAreaElement | null;
-const nhReplacement = document.getElementById('nh-replacement') as HTMLTextAreaElement | null;
-const nhOriginalCount = document.getElementById('nh-original-count');
-const nhReplacementCount = document.getElementById('nh-replacement-count');
-const nhOriginalError = document.getElementById('nh-original-error');
-const nhReplacementError = document.getElementById('nh-replacement-error');
-const nhCitationsContainer = document.getElementById('nh-citations');
-const nhCitationsError = document.getElementById('nh-citations-error');
-const nhCancel = document.getElementById('nh-cancel');
-
-type Citation = { url: string; explanation: string };
-let citations: Citation[] = [{ url: '', explanation: '' }];
 
 // set current url
 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -81,32 +64,9 @@ toggleButton?.addEventListener('click', async () => {
   await toggleHeadline();
 });
 
-// new-headline: open form
+// new-headline: open separate page
 replaceHeadlineButton?.addEventListener('click', () => {
-  openNewHeadlineView();
-});
-
-// new-headline: cancel
-nhCancel?.addEventListener('click', () => {
-  closeNewHeadlineView();
-});
-
-// new-headline: live counts
-nhOriginal?.addEventListener('input', () => updateCountsAndErrors());
-nhReplacement?.addEventListener('input', () => updateCountsAndErrors());
-
-// new-headline: submit
-newHeadlineForm?.addEventListener('submit', (e) => {
-  e.preventDefault();
-  const errors = validateNewHeadlineForm();
-  if (Object.keys(errors).length === 0) {
-    // mimic NewHeadline.tsx behavior: just log the values
-    console.log({
-      originalHeadline: nhOriginal?.value ?? '',
-      replacementHeadline: nhReplacement?.value ?? '',
-      citations: citations,
-    });
-  }
+  window.location.href = 'new_headline.html';
 });
 
 const STORED_DATA = 'storedHeadlineData';
@@ -185,152 +145,5 @@ function setButtonDisplayState(state: ButtonDisplayState): void {
       retrieveButton!.style.display = 'none';
       toggleButton!.style.display = 'block';
       break;
-  }
-}
-
-// =========================
-// New Headline view helpers
-// =========================
-
-function openNewHeadlineView(): void {
-  // hide transform controls
-  selectElement.style.display = 'none';
-  retrieveButton && (retrieveButton.style.display = 'none');
-  toggleButton && (toggleButton.style.display = 'none');
-  replaceHeadlineButton && (replaceHeadlineButton.style.display = 'none');
-
-  // initialize fields similar to NewHeadline defaults
-  if (nhOriginal) nhOriginal.value = 'New Study Proves Coffee Cures Cancer';
-  if (nhReplacement)
-    nhReplacement.value =
-      'Study Finds Correlation Between Coffee Consumption and Lower Risk of Certain Cancers';
-  citations = [{ url: '', explanation: '' }];
-  renderCitations();
-  updateCountsAndErrors(true);
-
-  // show view
-  if (newHeadlineView) newHeadlineView.style.display = 'block';
-}
-
-function closeNewHeadlineView(): void {
-  // hide view
-  if (newHeadlineView) newHeadlineView.style.display = 'none';
-
-  // show transform controls again
-  selectElement.style.display = 'block';
-  // do not force button state changes here; keep whatever state previously set
-  replaceHeadlineButton && (replaceHeadlineButton.style.display = 'inline-block');
-}
-
-function updateCountsAndErrors(clearOnly?: boolean): void {
-  const originalLength = nhOriginal?.value.length ?? 0;
-  const replacementLength = nhReplacement?.value.length ?? 0;
-
-  if (nhOriginalCount)
-    nhOriginalCount.textContent = `${originalLength} / ${MAX_HEADLINE_LENGTH}`;
-  if (nhReplacementCount)
-    nhReplacementCount.textContent = `${replacementLength} / ${MAX_HEADLINE_LENGTH}`;
-
-  if (clearOnly) {
-    if (nhOriginalError) nhOriginalError.style.display = 'none';
-    if (nhReplacementError) nhReplacementError.style.display = 'none';
-    if (nhCitationsError) nhCitationsError.style.display = 'none';
-    return;
-  }
-}
-
-function validateNewHeadlineForm(): {
-  originalHeadline?: string;
-  replacementHeadline?: string;
-  citations?: string;
-} {
-  const errors: { originalHeadline?: string; replacementHeadline?: string; citations?: string } = {};
-  const original = nhOriginal?.value ?? '';
-  const replacement = nhReplacement?.value ?? '';
-  if (!original.trim()) {
-    errors.originalHeadline = 'Original headline is required.';
-  } else if (original.length > MAX_HEADLINE_LENGTH) {
-    errors.originalHeadline = `Original headline must be at most ${MAX_HEADLINE_LENGTH} characters.`;
-  }
-  if (!replacement.trim()) {
-    errors.replacementHeadline = 'Replacement headline is required.';
-  } else if (replacement.length > MAX_HEADLINE_LENGTH) {
-    errors.replacementHeadline = `Replacement headline must be at most ${MAX_HEADLINE_LENGTH} characters.`;
-  }
-  const hasCitation = citations.some((c) => c.url.trim() !== '');
-  if (!hasCitation) {
-    errors.citations = 'At least one citation URL is required.';
-  }
-
-  // display errors
-  if (nhOriginalError) {
-    nhOriginalError.textContent = errors.originalHeadline ?? '';
-    nhOriginalError.style.display = errors.originalHeadline ? 'block' : 'none';
-  }
-  if (nhReplacementError) {
-    nhReplacementError.textContent = errors.replacementHeadline ?? '';
-    nhReplacementError.style.display = errors.replacementHeadline ? 'block' : 'none';
-  }
-  if (nhCitationsError) {
-    nhCitationsError.textContent = errors.citations ?? '';
-    nhCitationsError.style.display = errors.citations ? 'block' : 'none';
-  }
-
-  return errors;
-}
-
-function renderCitations(): void {
-  if (!nhCitationsContainer) return;
-  // clear existing
-  nhCitationsContainer.innerHTML = '';
-
-  citations.forEach((citation, idx) => {
-    const wrapper = document.createElement('div');
-    wrapper.style.marginBottom = '8px';
-
-    const urlInput = document.createElement('input');
-    urlInput.type = 'text';
-    urlInput.placeholder = 'https://...';
-    urlInput.value = citation.url;
-    urlInput.style.width = '100%';
-    urlInput.style.boxSizing = 'border-box';
-    urlInput.addEventListener('input', (e) => {
-      const value = (e.target as HTMLInputElement).value;
-      citations[idx] = { ...citations[idx], url: value };
-      if (idx === citations.length - 1 && value.trim() !== '') {
-        citations.push({ url: '', explanation: '' });
-      }
-      trimTrailingEmptyCitations();
-      renderCitations();
-      // keep any citations error visibility consistent
-      if (nhCitationsError) nhCitationsError.style.display = 'none';
-    });
-    wrapper.appendChild(urlInput);
-
-    const explanationArea = document.createElement('textarea');
-    explanationArea.placeholder = 'Optional explanation (e.g. what this citation supports)';
-    explanationArea.value = citation.explanation;
-    explanationArea.rows = 2;
-    explanationArea.style.width = '100%';
-    explanationArea.style.boxSizing = 'border-box';
-    explanationArea.style.fontSize = '12px';
-    explanationArea.style.marginTop = '4px';
-    explanationArea.addEventListener('input', (e) => {
-      const value = (e.target as HTMLTextAreaElement).value;
-      citations[idx] = { ...citations[idx], explanation: value };
-    });
-    wrapper.appendChild(explanationArea);
-
-    nhCitationsContainer.appendChild(wrapper);
-  });
-}
-
-function trimTrailingEmptyCitations(): void {
-  while (
-    citations.length > 1 &&
-    citations[citations.length - 1].url === '' &&
-    citations[citations.length - 2].url === ''
-  ) {
-    citations.pop();
   }
 }

--- a/apps/browser-extension/webpack.config.js
+++ b/apps/browser-extension/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
     contentScript: './src/contentScript.ts',
     background: './src/background.ts',
     popup: './src/popup.ts',
+    newHeadline: './src/newHeadline.ts',
     // Add other entry points if needed
   },
   output: {


### PR DESCRIPTION
Add 'Replace headline' button and form to the browser extension popup to allow users to propose new headlines, mirroring the functionality of `NewHeadline.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bca8f4c-cd44-45de-ba05-1ed941037fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9bca8f4c-cd44-45de-ba05-1ed941037fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

