### PR TITLE
Fix search returning 0 articles: don't break on parse failures

### DIFF
--- a/src/app/api/agent/process/[id]/route.ts
+++ b/src/app/api/agent/process/[id]/route.ts
@@ -347,7 +347,9 @@ export async function POST(
         WHERE id = ${run.id}
       `;
 
-      const searchResult = await searchForArticles(run.thesis, run.scope, undefined, keywords, isNearTimeout);
+      const searchResult = await searchForArticles(run.thesis, run.scope, async (msg) => {
+        await sql`UPDATE agent_runs SET stage_message = ${msg}, updated_at = now() WHERE id = ${run.id}`;
+      }, keywords, isNearTimeout);
       sonnetUsage.inputTokens += searchResult.usage.inputTokens;
       sonnetUsage.outputTokens += searchResult.usage.outputTokens;
       candidates = searchResult.candidates;

--- a/src/lib/agent/search.ts
+++ b/src/lib/agent/search.ts
@@ -208,17 +208,30 @@ If you cannot find any more relevant articles, return an empty array: []`;
       usage.outputTokens += response.usage.output_tokens;
     }
 
+    // Find the text block — Sonnet 4.6 with web_search may return
+    // multiple content blocks (web_search_tool_result + text).
+    // Look for any text block, even if it's not the first one.
     const textBlock = response.content.find((b) => b.type === "text");
-    if (!textBlock || textBlock.type !== "text") break;
+    if (!textBlock || textBlock.type !== "text") {
+      onProgress?.(`Search round ${round}: no text in response (${response.content.map((b) => b.type).join(", ")})`);
+      // Try to continue — maybe next round will work
+      round++;
+      continue;
+    }
 
     let candidates: ArticleCandidate[];
     try {
       candidates = JSON.parse(extractJSON(textBlock.text));
     } catch {
-      break;
+      onProgress?.(`Search round ${round}: JSON parse failed. Text starts with: ${textBlock.text.substring(0, 100)}...`);
+      round++;
+      continue;
     }
 
-    if (!Array.isArray(candidates) || candidates.length === 0) break;
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      onProgress?.(`Search round ${round}: empty or non-array result.`);
+      break;
+    }
 
     let newCount = 0;
     for (const c of candidates) {


### PR DESCRIPTION
The comprehensive Hasan Piker run spent $0.65 on 193K tokens but found zero articles. Claude web_search was running (high token count) but the response wasn't being parsed correctly.

Two issues:
1. If the text block was missing from the response, the loop broke immediately. Now it continues to the next round — Sonnet 4.6 with web_search may structure response blocks differently than 4.0.
2. If JSON parsing failed, the loop broke. Now it logs what it received and continues to the next round. This lets us see in the stage_message exactly what Claude returned.

Also: search progress messages are now written to the DB in real-time via the onProgress callback. The admin diagnostic will show messages like:
  "Search round 1: JSON parse failed. Text starts with: I found..."
  "Search round 2: no text in response (web_search_tool_result)"

This will reveal exactly why the search is failing to produce candidates despite spending tokens on web searches.

https://claude.ai/code/session_01SWYx2gkasLSMHK3FmQe5YH