### PR TITLE
Rebuild URL import extraction on cheerio — fixes near-total import fa…

### DIFF
--- a/spa/pages/SubmitScreen.jsx
+++ b/spa/pages/SubmitScreen.jsx
@@ -141,6 +141,10 @@ export default function SubmitScreen({ user, onUpdate, draftId, onDraftLoaded, o
         setImportMsg(`Imported ${imported.join(" and ")} from ${result.recipeUsed || result.platform || "page"}.`);
       } else if (Object.keys(fields).length > 0) {
         setImportMsg("Fields already filled — import skipped.");
+      } else if (result.fetchError && /403|401|429/.test(result.fetchError)) {
+        setImportMsg(`The site blocked our request (${result.fetchError}) — fill in fields manually.`);
+      } else if (result.fetchError) {
+        setImportMsg(`Couldn't fetch the page (${result.fetchError}) — fill in fields manually.`);
       } else {
         setImportMsg("No content found on page.");
       }

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,20 +1,24 @@
 import { NextRequest } from "next/server";
 import { ok, err } from "@/lib/api-utils";
+import {
+  fetchHtml,
+  extractAllFields,
+  extractBodyText,
+  type Fields,
+  type FieldResult,
+} from "@/lib/import/extract";
 import registryData from "../../../../site-registry.json";
 
 // In-memory cache (24h TTL)
 const cache = new Map<string, { data: ImportResult; timestamp: number }>();
 const CACHE_TTL = 24 * 60 * 60 * 1000;
 
-const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
-
-interface FieldResult { value: string; source: string; confidence: number; }
 interface ImportResult {
   success: boolean;
   platform: string;
   template: string;
   confidence: number;
-  fields: Record<string, FieldResult>;
+  fields: Fields;
   canonical: string;
   submitted: string;
   normalized: string;
@@ -30,7 +34,12 @@ const registry = registryData as Record<string, unknown>;
 const recipes = (registry.recipes || {}) as Record<string, Record<string, unknown>>;
 
 function findRecipe(rawUrl: string): { key: string; recipe: Record<string, unknown> } | null {
-  const hostname = new URL(rawUrl).hostname.replace(/^www\./, "");
+  let hostname: string;
+  try {
+    hostname = new URL(rawUrl).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
   for (const [key, recipe] of Object.entries(recipes)) {
     if (key.startsWith("_")) continue;
     const domains = recipe.domains as string[] | undefined;
@@ -53,7 +62,12 @@ const GLOBAL_STRIP_PARAMS = [
 ];
 
 function normalizeUrl(rawUrl: string, recipe: Record<string, unknown> | null): string {
-  const url = new URL(rawUrl);
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
   GLOBAL_STRIP_PARAMS.forEach(p => url.searchParams.delete(p));
   const normRules = recipe?.urlNormalization as Record<string, unknown> | undefined;
   if (normRules?.stripParams) {
@@ -72,188 +86,9 @@ function normalizeUrl(rawUrl: string, recipe: Record<string, unknown> | null): s
   return url.toString();
 }
 
-// ─── Regex-Based Extraction (ported from article-meta) ─────────────
+// ─── Platform APIs ─────────────────────────────────────────────────
 
-function decodeEntities(str: string): string {
-  return str
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)))
-    .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&nbsp;/g, " ");
-}
-
-function getMetaContent(html: string, nameOrProp: string): string | null {
-  const patterns = [
-    new RegExp(`<meta[^>]+(?:name|property)=["']${nameOrProp}["'][^>]+content=["']([^"']+)["']`, "i"),
-    new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+(?:name|property)=["']${nameOrProp}["']`, "i"),
-  ];
-  for (const pattern of patterns) {
-    const match = html.match(pattern);
-    if (match?.[1]) return decodeEntities(match[1].trim());
-  }
-  return null;
-}
-
-// Layer 1: Meta tags (og, twitter, standard)
-function extractMetaFields(html: string): Record<string, FieldResult> {
-  const fields: Record<string, FieldResult> = {};
-  const metaMappings: Array<{ field: string; tags: string[]; confidence: number }> = [
-    { field: "title", tags: ["og:title", "twitter:title"], confidence: 0.8 },
-    { field: "description", tags: ["og:description", "twitter:description", "description"], confidence: 0.7 },
-    { field: "author", tags: ["article:author", "author", "twitter:creator", "sailthru.author", "dc.creator"], confidence: 0.7 },
-    { field: "publishDate", tags: ["article:published_time", "date", "pubdate"], confidence: 0.7 },
-    { field: "siteName", tags: ["og:site_name", "twitter:site", "application-name"], confidence: 0.7 },
-    { field: "thumbnail", tags: ["og:image", "twitter:image"], confidence: 0.8 },
-  ];
-  for (const { field, tags, confidence } of metaMappings) {
-    for (const tag of tags) {
-      const value = getMetaContent(html, tag);
-      if (value) { fields[field] = { value, source: "meta", confidence }; break; }
-    }
-  }
-  return fields;
-}
-
-// Layer 2: JSON-LD structured data
-function extractJsonLd(html: string): Record<string, FieldResult> {
-  const fields: Record<string, FieldResult> = {};
-  // Find ALL JSON-LD blocks
-  const ldPattern = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
-  let match;
-  while ((match = ldPattern.exec(html)) !== null) {
-    try {
-      let data = JSON.parse(match[1]);
-      if (data["@graph"]) data = data["@graph"];
-      if (!Array.isArray(data)) data = [data];
-      for (const item of data) {
-        const type = item["@type"];
-        // Articles
-        if (["NewsArticle", "Article", "BlogPosting", "WebPage", "ReportageNewsArticle"].includes(type)) {
-          if (item.headline && !fields.title) fields.title = { value: decodeEntities(String(item.headline)), source: "json-ld", confidence: 0.9 };
-          if (item.description && !fields.description) fields.description = { value: decodeEntities(String(item.description)), source: "json-ld", confidence: 0.85 };
-          if (item.author) {
-            const authors = Array.isArray(item.author) ? item.author : [item.author];
-            const names = authors.map((a: Record<string, string>) => a?.name || (typeof a === "string" ? a : null)).filter(Boolean);
-            if (names.length > 0 && !fields.author) fields.author = { value: names.join(", "), source: "json-ld", confidence: 0.9 };
-          }
-          if (item.datePublished && !fields.publishDate) fields.publishDate = { value: String(item.datePublished), source: "json-ld", confidence: 0.9 };
-          if (item.publisher?.name && !fields.publication) fields.publication = { value: String(item.publisher.name), source: "json-ld", confidence: 0.9 };
-        }
-        // Products
-        if (type === "Product") {
-          if (item.name && !fields.title) fields.title = { value: decodeEntities(String(item.name)), source: "json-ld", confidence: 0.95 };
-          if (item.brand?.name && !fields.brand) fields.brand = { value: String(item.brand.name), source: "json-ld", confidence: 0.95 };
-          if (item.description && !fields.description) fields.description = { value: decodeEntities(String(item.description)), source: "json-ld", confidence: 0.85 };
-          if (item.aggregateRating && !fields.rating) {
-            fields.rating = { value: `${item.aggregateRating.ratingValue}/${item.aggregateRating.bestRating || 5} (${item.aggregateRating.reviewCount || "?"} reviews)`, source: "json-ld", confidence: 0.95 };
-          }
-        }
-        // Videos
-        if (type === "VideoObject") {
-          if (item.name && !fields.title) fields.title = { value: decodeEntities(String(item.name)), source: "json-ld", confidence: 0.9 };
-          if (item.duration && !fields.duration) fields.duration = { value: String(item.duration), source: "json-ld", confidence: 0.9 };
-          if (item.author?.name && !fields.author) fields.author = { value: String(item.author.name), source: "json-ld", confidence: 0.9 };
-        }
-        // Podcasts
-        if (["PodcastEpisode", "AudioObject", "RadioEpisode"].includes(type)) {
-          if (item.name && !fields.title) fields.title = { value: decodeEntities(String(item.name)), source: "json-ld", confidence: 0.9 };
-          if (item.duration && !fields.duration) fields.duration = { value: String(item.duration), source: "json-ld", confidence: 0.9 };
-          if (item.partOfSeries?.name && !fields.showName) fields.showName = { value: String(item.partOfSeries.name), source: "json-ld", confidence: 0.9 };
-        }
-      }
-    } catch { /* invalid JSON-LD */ }
-  }
-  return fields;
-}
-
-// Layer 3: HTML fallbacks
-function extractHtmlFallbacks(html: string): Record<string, FieldResult> {
-  const fields: Record<string, FieldResult> = {};
-
-  // <title> tag (strip common suffixes)
-  if (!fields.title) {
-    const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-    if (titleMatch?.[1]) {
-      let title = decodeEntities(titleMatch[1].trim());
-      title = title.replace(/\s*[\|\-–—]\s*[^|\-–—]{2,30}$/, "").trim();
-      if (title.length > 10) fields.title = { value: title, source: "html-title", confidence: 0.6 };
-    }
-  }
-
-  // First <h1>
-  if (!fields.title) {
-    const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
-    if (h1Match?.[1]) {
-      const h1 = decodeEntities(h1Match[1].replace(/<[^>]+>/g, "").trim());
-      if (h1.length > 5) fields.title = { value: h1, source: "html-h1", confidence: 0.5 };
-    }
-  }
-
-  // Author from <a rel="author">
-  const relAuthorMatch = html.match(/<a[^>]+rel=["']author["'][^>]*>([^<]+)<\/a>/gi);
-  if (relAuthorMatch && !fields.author) {
-    const names: string[] = [];
-    for (const m of relAuthorMatch) {
-      const nameMatch = m.match(/>([^<]+)</);
-      if (nameMatch?.[1]) names.push(decodeEntities(nameMatch[1].trim()));
-    }
-    if (names.length > 0) fields.author = { value: names.join(", "), source: "html-rel-author", confidence: 0.6 };
-  }
-
-  // Canonical URL
-  const canonicalMatch = html.match(/<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i);
-  if (canonicalMatch?.[1]) fields._canonical = { value: canonicalMatch[1], source: "html", confidence: 1.0 };
-  if (!fields._canonical) {
-    const ogUrl = getMetaContent(html, "og:url");
-    if (ogUrl) fields._canonical = { value: ogUrl, source: "meta", confidence: 0.9 };
-  }
-
-  return fields;
-}
-
-// Body text extraction via regex (replaces Readability)
-function extractBodyText(html: string): string | null {
-  // Remove script and style tags
-  const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "");
-
-  let container: string | null = null;
-  // Try <article> tag first
-  const articleMatch = cleaned.match(/<article[\s\S]*?>([\s\S]*?)<\/article>/i);
-  if (articleMatch?.[1]) container = articleMatch[1];
-
-  // Fallback to common article body selectors
-  if (!container) {
-    const selectors = [
-      /role=["']article["']/i,
-      /class=["'][^"']*\barticle-body\b[^"']*["']/i,
-      /class=["'][^"']*\bpost-content\b[^"']*["']/i,
-      /class=["'][^"']*\bentry-content\b[^"']*["']/i,
-      /class=["'][^"']*\bstory-body\b[^"']*["']/i,
-    ];
-    for (const selector of selectors) {
-      const tagPattern = new RegExp(`<(\\w+)[^>]*${selector.source}[^>]*>([\\s\\S]*?)<\\/\\1>`, "i");
-      const match = cleaned.match(tagPattern);
-      if (match?.[2]) { container = match[2]; break; }
-    }
-  }
-
-  // Extract <p> tags
-  const source = container || cleaned;
-  const pMatches = source.match(/<p[\s\S]*?>([\s\S]*?)<\/p>/gi);
-  if (!pMatches || pMatches.length === 0) return null;
-
-  const paragraphs = pMatches
-    .map(p => decodeEntities(p.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim()))
-    .filter(text => text.length > 30); // skip short fragments
-
-  if (paragraphs.length === 0) return null;
-  return paragraphs.join("\n\n").slice(0, 10000);
-}
-
-// Layer 4: Platform APIs
-async function extractWithRedditJson(url: string): Promise<Record<string, FieldResult> | null> {
+async function extractWithRedditJson(url: string): Promise<Fields | null> {
   try {
     // Append .json to the path (before query string)
     const u = new URL(url);
@@ -270,7 +105,7 @@ async function extractWithRedditJson(url: string): Promise<Record<string, FieldR
     const data = await response.json();
     const post = data?.[0]?.data?.children?.[0]?.data;
     if (!post) return null;
-    const fields: Record<string, FieldResult> = {};
+    const fields: Fields = {};
     if (post.title) fields.title = { value: post.title, source: "reddit-json", confidence: 1.0 };
     if (post.author) fields.author = { value: `u/${post.author}`, source: "reddit-json", confidence: 1.0 };
     if (post.selftext) fields.body = { value: post.selftext, source: "reddit-json", confidence: 1.0 };
@@ -282,7 +117,7 @@ async function extractWithRedditJson(url: string): Promise<Record<string, FieldR
 }
 
 // Apply site registry metaHints (title stripping, field preferences)
-function applyMetaHints(fields: Record<string, FieldResult>, recipe: Record<string, unknown> | null): void {
+function applyMetaHints(fields: Fields, recipe: Record<string, unknown> | null): void {
   const hints = recipe?.metaHints as Record<string, string> | undefined;
   if (!hints) return;
 
@@ -310,78 +145,29 @@ async function importUrl(rawUrl: string): Promise<ImportResult> {
   const template = (recipe?.template as string) || "article";
 
   // Platform APIs (Reddit JSON)
-  let specialFields: Record<string, FieldResult> | null = null;
+  let specialFields: Fields | null = null;
   if (recipe?.extractionStrategy === "reddit_json" || normalizedUrl.includes("reddit.com")) {
     specialFields = await extractWithRedditJson(normalizedUrl);
   }
 
-  // Fetch HTML (first 200KB only — meta tags are in <head>)
-  let html: string | null = null;
-  let fetchError: string | null = null;
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 8000);
-    const response = await fetch(normalizedUrl, {
-      headers: {
-        "User-Agent": USER_AGENT,
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Accept-Encoding": "gzip, deflate",
-        "Cache-Control": "no-cache",
-      },
-      redirect: "follow",
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-    if (response.ok) {
-      // Read only first 200KB
-      const reader = response.body?.getReader();
-      if (reader) {
-        const decoder = new TextDecoder();
-        let totalBytes = 0;
-        const MAX_BYTES = 200_000;
-        html = "";
-        while (totalBytes < MAX_BYTES) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          html += decoder.decode(value, { stream: true });
-          totalBytes += value.length;
-        }
-        reader.cancel().catch(() => {});
-      }
-    } else {
-      fetchError = `HTTP ${response.status}`;
-      console.warn(`[import] Fetch failed for ${normalizedUrl}: ${fetchError}`);
-    }
-  } catch (e) {
-    fetchError = e instanceof Error ? e.message : String(e);
-    console.warn(`[import] Fetch error for ${normalizedUrl}: ${fetchError}`);
-  }
+  const { html, error: fetchError } = await fetchHtml(normalizedUrl);
+  if (fetchError) console.warn(`[import] Fetch failed for ${normalizedUrl}: ${fetchError}`);
 
   // Run extraction layers — earlier layers fill first, later layers only fill gaps
-  let fields: Record<string, FieldResult> = {};
+  let fields: Fields = {};
 
-  // Layer 4 first (API results are highest confidence)
+  // Platform API results first (highest confidence)
   if (specialFields) {
     for (const [key, val] of Object.entries(specialFields)) { if (!fields[key]) fields[key] = val; }
   }
 
   if (html) {
-    // Layer 2: JSON-LD (high confidence, structured data)
-    const jsonLdFields = extractJsonLd(html);
-    for (const [key, val] of Object.entries(jsonLdFields)) { if (!fields[key]) fields[key] = val; }
-
-    // Layer 1: Meta tags
-    const metaFields = extractMetaFields(html);
-    for (const [key, val] of Object.entries(metaFields)) { if (!fields[key]) fields[key] = val; }
-
-    // Layer 3: HTML fallbacks
-    const htmlFields = extractHtmlFallbacks(html);
+    // Recipe selectors → JSON-LD → meta tags → HTML fallbacks
+    const htmlFields = extractAllFields(html, recipe);
     for (const [key, val] of Object.entries(htmlFields)) { if (!fields[key]) fields[key] = val; }
 
-    // Body text extraction (regex-based, replaces Readability)
     if (!fields.body) {
-      const bodyText = extractBodyText(html);
+      const bodyText = extractBodyText(html, recipe);
       if (bodyText) fields.body = { value: bodyText, source: "html-body", confidence: 0.5 };
     }
   }
@@ -405,7 +191,7 @@ async function importUrl(rawUrl: string): Promise<ImportResult> {
   }
 
   // Compute overall confidence
-  const fieldValues = Object.values(fields);
+  const fieldValues = Object.values(fields) as FieldResult[];
   const avgConfidence = fieldValues.length > 0
     ? fieldValues.reduce((sum, f) => sum + f.confidence, 0) / fieldValues.length
     : 0;

--- a/src/lib/import/extract.ts
+++ b/src/lib/import/extract.ts
@@ -1,0 +1,451 @@
+// Trust Assembly Import Service — extraction engine
+// ----------------------------------------------------
+// Cheerio-based extraction shared by /api/import. Replaces the old
+// regex extraction, which truncated values at apostrophes, missed
+// JSON-LD @type arrays, and captured nested containers incorrectly.
+//
+// Extraction layers (earlier layers win, later layers fill gaps):
+//   0. Site-registry CSS selectors (per-site recipes)
+//   1. JSON-LD structured data
+//   2. Meta tags (og:, twitter:, standard)
+//   3. HTML fallbacks (<title>, <h1>, rel=author, canonical)
+//   4. Body text (recipe selector → scored containers → all <p>)
+
+import * as cheerio from "cheerio";
+import type { CheerioAPI } from "cheerio";
+
+export interface FieldResult {
+  value: string;
+  source: string;
+  confidence: number;
+}
+
+export type Fields = Record<string, FieldResult>;
+
+// ─── Fetching ──────────────────────────────────────────────────────
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+const BOT_UA =
+  "Mozilla/5.0 (compatible; TrustAssembly/1.0; +https://trustassembly.org)";
+
+const FETCH_TIMEOUT_MS = 9000;
+// Modern news pages run 500KB-2MB of HTML; the old 200KB cap cut
+// JSON-LD blocks and article bodies in half.
+const MAX_BYTES = 1_500_000;
+
+export interface FetchHtmlResult {
+  html: string | null;
+  error: string | null;
+  httpStatus?: number;
+}
+
+async function fetchOnce(url: string, userAgent: string): Promise<FetchHtmlResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": userAgent,
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Cache-Control": "no-cache",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Upgrade-Insecure-Requests": "1",
+      },
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return { html: null, error: `HTTP ${response.status}`, httpStatus: response.status };
+    }
+
+    // Read up to MAX_BYTES, then decode with the declared charset
+    const reader = response.body?.getReader();
+    if (!reader) return { html: null, error: "Empty response body" };
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    while (totalBytes < MAX_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      totalBytes += value.length;
+    }
+    reader.cancel().catch(() => {});
+
+    const bytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk.subarray(0, totalBytes - offset), offset);
+      offset += chunk.length;
+      if (offset >= totalBytes) break;
+    }
+    return { html: decodeHtmlBytes(bytes, response.headers.get("content-type")), error: null };
+  } catch (e) {
+    const message = e instanceof Error ? (e.name === "AbortError" ? "Timed out" : e.message) : String(e);
+    return { html: null, error: message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function decodeHtmlBytes(bytes: Uint8Array, contentType: string | null): string {
+  const headerCharset = contentType?.match(/charset=([\w-]+)/i)?.[1];
+  if (headerCharset) {
+    try {
+      return new TextDecoder(headerCharset.toLowerCase()).decode(bytes);
+    } catch { /* unknown label — fall through to UTF-8 */ }
+  }
+  const utf8 = new TextDecoder("utf-8").decode(bytes);
+  // No charset header — check for a <meta charset> declaration
+  const metaCharset = utf8.slice(0, 2048).match(/charset=["']?([\w-]+)/i)?.[1]?.toLowerCase();
+  if (metaCharset && metaCharset !== "utf-8" && metaCharset !== "utf8") {
+    try {
+      return new TextDecoder(metaCharset).decode(bytes);
+    } catch { /* unknown label */ }
+  }
+  return utf8;
+}
+
+// Fetch with a browser UA first; on a block (401/403/429/503) retry
+// once with the identified-crawler UA, which some publishers allow.
+export async function fetchHtml(url: string): Promise<FetchHtmlResult> {
+  const first = await fetchOnce(url, BROWSER_UA);
+  if (first.html) return first;
+  if (first.httpStatus && [401, 403, 429, 503].includes(first.httpStatus)) {
+    const second = await fetchOnce(url, BOT_UA);
+    if (second.html) return second;
+  }
+  return first;
+}
+
+// ─── Layer 0: Site-registry CSS selectors ──────────────────────────
+
+interface SelectorRule {
+  css?: string;
+  attr?: string | null;
+  multi?: boolean;
+  separator?: string;
+  fallback?: string;
+  strategy?: string;
+}
+
+function extractWithSelector($: CheerioAPI, rule: SelectorRule): string | null {
+  if (!rule.css) return null;
+  let elements;
+  try {
+    elements = $(rule.css);
+  } catch {
+    return null; // invalid selector in registry
+  }
+  if (elements.length === 0) return null;
+
+  const readOne = (el: ReturnType<CheerioAPI>) =>
+    (rule.attr ? el.attr(rule.attr) : el.text())?.trim() || null;
+
+  if (rule.multi) {
+    const values: string[] = [];
+    elements.each((_, el) => {
+      const v = readOne($(el));
+      if (v && !values.includes(v)) values.push(v);
+    });
+    return values.length > 0 ? values.join(rule.separator || ", ") : null;
+  }
+  return readOne(elements.first());
+}
+
+export function extractRecipeFields(
+  $: CheerioAPI,
+  recipe: Record<string, unknown> | null
+): Fields {
+  const fields: Fields = {};
+  const selectors = recipe?.selectors as Record<string, SelectorRule> | undefined;
+  if (!selectors) return fields;
+
+  for (const [field, rule] of Object.entries(selectors)) {
+    if (field === "body") continue; // handled by extractBodyText
+    const value = extractWithSelector($, rule);
+    if (value) fields[field] = { value, source: "recipe", confidence: 0.95 };
+  }
+  return fields;
+}
+
+// ─── Layer 1: JSON-LD structured data ──────────────────────────────
+
+const ARTICLE_TYPES = new Set([
+  "NewsArticle", "Article", "BlogPosting", "WebPage", "ReportageNewsArticle",
+  "LiveBlogPosting", "OpinionNewsArticle", "AnalysisNewsArticle",
+  "BackgroundNewsArticle", "ScholarlyArticle", "TechArticle", "SocialMediaPosting",
+]);
+
+// @type may be a string or an array of strings
+function typeMatches(rawType: unknown, allowed: Set<string>): boolean {
+  const types = Array.isArray(rawType) ? rawType : [rawType];
+  return types.some((t) => typeof t === "string" && allowed.has(t));
+}
+
+function authorNames(rawAuthor: unknown): string | null {
+  const authors = Array.isArray(rawAuthor) ? rawAuthor : [rawAuthor];
+  const names = authors
+    .map((a) => {
+      if (typeof a === "string") return a.trim();
+      if (a && typeof a === "object") {
+        const name = (a as Record<string, unknown>).name;
+        return typeof name === "string" ? name.trim() : null;
+      }
+      return null;
+    })
+    .filter((n): n is string => !!n && n.length > 0);
+  return names.length > 0 ? [...new Set(names)].join(", ") : null;
+}
+
+export function extractJsonLd($: CheerioAPI): Fields {
+  const fields: Fields = {};
+  const setOnce = (key: string, value: unknown, confidence: number) => {
+    if (fields[key]) return;
+    const str = typeof value === "string" ? value.trim() : String(value ?? "").trim();
+    if (str) fields[key] = { value: str, source: "json-ld", confidence };
+  };
+
+  $('script[type="application/ld+json"]').each((_, el) => {
+    const raw = $(el).text();
+    if (!raw?.trim()) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return; // malformed or truncated JSON-LD
+    }
+
+    // Flatten top-level arrays and @graph containers
+    const items: Record<string, unknown>[] = [];
+    const queue = Array.isArray(parsed) ? [...parsed] : [parsed];
+    while (queue.length > 0) {
+      const node = queue.shift();
+      if (!node || typeof node !== "object") continue;
+      const obj = node as Record<string, unknown>;
+      if (Array.isArray(obj["@graph"])) queue.push(...(obj["@graph"] as unknown[]));
+      if (obj["@type"]) items.push(obj);
+    }
+
+    for (const item of items) {
+      if (typeMatches(item["@type"], ARTICLE_TYPES)) {
+        setOnce("title", item.headline || item.name, 0.9);
+        setOnce("description", item.description, 0.85);
+        if (item.author && !fields.author) {
+          const names = authorNames(item.author);
+          if (names) fields.author = { value: names, source: "json-ld", confidence: 0.9 };
+        }
+        setOnce("publishDate", item.datePublished, 0.9);
+        const publisher = item.publisher as Record<string, unknown> | undefined;
+        setOnce("publication", publisher?.name, 0.9);
+        const image = item.image as Record<string, unknown> | string | string[] | undefined;
+        if (typeof image === "string") setOnce("thumbnail", image, 0.85);
+        else if (Array.isArray(image)) setOnce("thumbnail", image[0], 0.85);
+        else if (image?.url) setOnce("thumbnail", image.url, 0.85);
+      }
+      if (typeMatches(item["@type"], new Set(["Product"]))) {
+        setOnce("title", item.name, 0.95);
+        const brand = item.brand as Record<string, unknown> | undefined;
+        setOnce("brand", typeof item.brand === "string" ? item.brand : brand?.name, 0.95);
+        setOnce("description", item.description, 0.85);
+        const rating = item.aggregateRating as Record<string, unknown> | undefined;
+        if (rating?.ratingValue && !fields.rating) {
+          fields.rating = {
+            value: `${rating.ratingValue}/${rating.bestRating || 5} (${rating.reviewCount || "?"} reviews)`,
+            source: "json-ld",
+            confidence: 0.95,
+          };
+        }
+      }
+      if (typeMatches(item["@type"], new Set(["VideoObject"]))) {
+        setOnce("title", item.name, 0.9);
+        setOnce("duration", item.duration, 0.9);
+        const author = item.author as Record<string, unknown> | undefined;
+        setOnce("author", author?.name, 0.9);
+      }
+      if (typeMatches(item["@type"], new Set(["PodcastEpisode", "AudioObject", "RadioEpisode"]))) {
+        setOnce("title", item.name, 0.9);
+        setOnce("duration", item.duration, 0.9);
+        const series = item.partOfSeries as Record<string, unknown> | undefined;
+        setOnce("showName", series?.name, 0.9);
+      }
+    }
+  });
+
+  return fields;
+}
+
+// ─── Layer 2: Meta tags ────────────────────────────────────────────
+
+function getMeta($: CheerioAPI, nameOrProp: string): string | null {
+  const value =
+    $(`meta[property="${nameOrProp}"]`).attr("content") ||
+    $(`meta[name="${nameOrProp}"]`).attr("content") ||
+    $(`meta[itemprop="${nameOrProp}"]`).attr("content");
+  return value?.trim() || null;
+}
+
+export function extractMetaFields($: CheerioAPI): Fields {
+  const fields: Fields = {};
+  const metaMappings: Array<{ field: string; tags: string[]; confidence: number }> = [
+    { field: "title", tags: ["og:title", "twitter:title"], confidence: 0.8 },
+    { field: "description", tags: ["og:description", "twitter:description", "description"], confidence: 0.7 },
+    { field: "author", tags: ["article:author", "author", "parsely-author", "sailthru.author", "dc.creator", "twitter:creator", "byl"], confidence: 0.7 },
+    { field: "publishDate", tags: ["article:published_time", "parsely-pub-date", "date", "pubdate", "sailthru.date"], confidence: 0.7 },
+    { field: "siteName", tags: ["og:site_name", "twitter:site", "application-name"], confidence: 0.7 },
+    { field: "thumbnail", tags: ["og:image", "twitter:image"], confidence: 0.8 },
+  ];
+  for (const { field, tags, confidence } of metaMappings) {
+    for (const tag of tags) {
+      const value = getMeta($, tag);
+      // article:author is sometimes a profile URL, not a name — skip those
+      if (value && !(field === "author" && /^https?:\/\//.test(value))) {
+        fields[field] = { value, source: "meta", confidence };
+        break;
+      }
+    }
+  }
+  return fields;
+}
+
+// ─── Layer 3: HTML fallbacks ───────────────────────────────────────
+
+export function extractHtmlFallbacks($: CheerioAPI): Fields {
+  const fields: Fields = {};
+
+  const titleTag = $("title").first().text().trim();
+  if (titleTag) {
+    // Strip common " | Site Name" suffixes
+    const stripped = titleTag.replace(/\s*[|\-–—]\s*[^|\-–—]{2,40}$/, "").trim();
+    const title = stripped.length > 10 ? stripped : titleTag;
+    if (title.length > 3) fields.title = { value: title, source: "html-title", confidence: 0.6 };
+  }
+
+  const h1 = $("h1").first().text().replace(/\s+/g, " ").trim();
+  if (!fields.title && h1.length > 5) {
+    fields.title = { value: h1, source: "html-h1", confidence: 0.5 };
+  }
+
+  const authorLinks: string[] = [];
+  $('a[rel="author"]').each((_, el) => {
+    const name = $(el).text().trim();
+    if (name && !authorLinks.includes(name)) authorLinks.push(name);
+  });
+  if (authorLinks.length > 0) {
+    fields.author = { value: authorLinks.join(", "), source: "html-rel-author", confidence: 0.6 };
+  }
+
+  const time = $("time[datetime]").first().attr("datetime")?.trim();
+  if (time) fields.publishDate = { value: time, source: "html-time", confidence: 0.6 };
+
+  const canonical = $('link[rel="canonical"]').attr("href")?.trim() || getMeta($, "og:url");
+  if (canonical) fields._canonical = { value: canonical, source: "html", confidence: 1.0 };
+
+  return fields;
+}
+
+// ─── Layer 4: Body text ────────────────────────────────────────────
+
+const BODY_CONTAINER_SELECTORS = [
+  '[itemprop="articleBody"]',
+  "article",
+  '[role="article"]',
+  ".article-body", ".article__body", ".article-content", ".article__content",
+  ".story-body", ".story-content",
+  ".post-content", ".post-body", ".entry-content",
+  ".rich-text", ".body-copy",
+  "main",
+];
+
+const NOISE_SELECTORS = [
+  "script", "style", "noscript", "template", "svg", "iframe", "form",
+  "nav", "header", "footer", "aside", "figure", "button",
+  '[class*="advert"]', '[class*="promo"]', '[class*="newsletter"]',
+  '[class*="related"]', '[class*="comment"]', '[class*="share"]',
+  '[class*="social"]', '[class*="sidebar"]', '[class*="paywall"]',
+  '[id*="advert"]', '[id*="sidebar"]', '[id*="comment"]',
+].join(", ");
+
+const MAX_BODY_CHARS = 10000;
+const MIN_PARAGRAPH_CHARS = 30;
+
+function paragraphsFrom($: CheerioAPI, container: ReturnType<CheerioAPI>): string[] {
+  const paragraphs: string[] = [];
+  container.find("p, blockquote, h2, h3, li").each((_, el) => {
+    // Skip elements nested inside another collected element (e.g. <p> in <blockquote>)
+    if ($(el).parents("blockquote, li").length > 0) return;
+    const text = $(el).text().replace(/\s+/g, " ").trim();
+    if (text.length >= MIN_PARAGRAPH_CHARS) paragraphs.push(text);
+  });
+  return paragraphs;
+}
+
+export function extractBodyText(html: string, recipe: Record<string, unknown> | null): string | null {
+  const $ = cheerio.load(html);
+  $(NOISE_SELECTORS).remove();
+
+  // Recipe body selector — collect paragraph elements directly
+  const bodyRule = (recipe?.selectors as Record<string, SelectorRule> | undefined)?.body;
+  if (bodyRule?.css) {
+    try {
+      const elements = $(bodyRule.css);
+      if (elements.length > 0) {
+        const paragraphs: string[] = [];
+        elements.each((_, el) => {
+          const text = $(el).text().replace(/\s+/g, " ").trim();
+          if (text.length >= MIN_PARAGRAPH_CHARS) paragraphs.push(text);
+        });
+        if (paragraphs.length > 0) return paragraphs.join("\n\n").slice(0, MAX_BODY_CHARS);
+      }
+    } catch { /* invalid selector — fall through */ }
+  }
+
+  // Score candidate containers by total paragraph text; pick the best
+  // rather than the first match, so a stub <article> in a sidebar
+  // doesn't shadow the real story body.
+  let bestParagraphs: string[] = [];
+  let bestScore = 0;
+  for (const selector of BODY_CONTAINER_SELECTORS) {
+    $(selector).each((_, el) => {
+      const paragraphs = paragraphsFrom($, $(el));
+      const score = paragraphs.reduce((sum, p) => sum + p.length, 0);
+      if (score > bestScore) {
+        bestScore = score;
+        bestParagraphs = paragraphs;
+      }
+    });
+    if (bestScore > 1500) break; // strong match — no need to scan weaker selectors
+  }
+
+  if (bestScore < 200) {
+    // Last resort: every <p> on the page
+    const all = paragraphsFrom($, $("body"));
+    const allScore = all.reduce((sum, p) => sum + p.length, 0);
+    if (allScore > bestScore) bestParagraphs = all;
+  }
+
+  if (bestParagraphs.length === 0) return null;
+  return bestParagraphs.join("\n\n").slice(0, MAX_BODY_CHARS);
+}
+
+// ─── Combined extraction ───────────────────────────────────────────
+
+export function extractAllFields(html: string, recipe: Record<string, unknown> | null): Fields {
+  const $ = cheerio.load(html);
+  const fields: Fields = {};
+  const layers = [
+    extractRecipeFields($, recipe),
+    extractJsonLd($),
+    extractMetaFields($),
+    extractHtmlFallbacks($),
+  ];
+  for (const layer of layers) {
+    for (const [key, value] of Object.entries(layer)) {
+      if (!fields[key]) fields[key] = value;
+    }
+  }
+  return fields;
+}

--- a/tests/import-extract.test.ts
+++ b/tests/import-extract.test.ts
@@ -1,0 +1,235 @@
+// Import service extraction tests
+// ----------------------------------
+// Offline fixtures modeled on real-world article HTML. Each fixture
+// reproduces a failure mode of the old regex-based extractor.
+//
+// Run with:
+//   node --experimental-strip-types tests/import-extract.test.ts
+
+import { strict as assert } from "node:assert";
+import {
+  extractAllFields,
+  extractBodyText,
+} from "../src/lib/import/extract.ts";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok    ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  FAIL  ${name}`);
+    console.error(`        ${e instanceof Error ? e.message : e}`);
+  }
+}
+
+// ─── Fixture 1: apostrophes + reversed attribute order in meta tags ──
+// The old regex `content=["']([^"']+)["']` truncated "Trump's plan…"
+// to "Trump" and required name/property to come first.
+
+const APOSTROPHE_HTML = `<!DOCTYPE html><html><head>
+<meta property="og:title" content="Trump's plan sparks debate over 'emergency' powers">
+<meta content="The president's allies say it's legal. Critics aren't sure." property="og:description">
+<meta name="author" content="Jane O'Brien, Sam D'Angelo">
+<title>Trump's plan sparks debate | The Daily Record</title>
+</head><body><h1>Trump's plan sparks debate</h1></body></html>`;
+
+test("meta extraction survives apostrophes in attribute values", () => {
+  const fields = extractAllFields(APOSTROPHE_HTML, null);
+  assert.equal(fields.title?.value, "Trump's plan sparks debate over 'emergency' powers");
+});
+
+test("meta extraction handles content= before property=", () => {
+  const fields = extractAllFields(APOSTROPHE_HTML, null);
+  assert.equal(fields.description?.value, "The president's allies say it's legal. Critics aren't sure.");
+});
+
+test("author with apostrophes extracts fully", () => {
+  const fields = extractAllFields(APOSTROPHE_HTML, null);
+  assert.equal(fields.author?.value, "Jane O'Brien, Sam D'Angelo");
+});
+
+// ─── Fixture 2: JSON-LD with @graph and @type arrays ────────────────
+// Major outlets (NYT, Guardian, WaPo) emit `"@type": ["NewsArticle"]`
+// inside an @graph container. The old code compared the array itself
+// against a string list, so the layer never matched.
+
+const JSONLD_HTML = `<!DOCTYPE html><html><head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "Organization", "name": "The Gazette" },
+    {
+      "@type": ["NewsArticle", "Article"],
+      "headline": "Senate passes \\"landmark\\" climate bill after all-night session",
+      "description": "The 51-49 vote followed months of negotiation.",
+      "datePublished": "2026-06-01T08:30:00Z",
+      "author": [{ "@type": "Person", "name": "Maria Chen" }, { "@type": "Person", "name": "Tom Walsh" }],
+      "publisher": { "@type": "Organization", "name": "The Gazette" },
+      "image": { "@type": "ImageObject", "url": "https://gazette.example/img/climate.jpg" }
+    }
+  ]
+}
+</script>
+<meta property="og:title" content="Senate passes landmark climate bill - The Gazette">
+</head><body></body></html>`;
+
+test("JSON-LD with @type array inside @graph extracts headline", () => {
+  const fields = extractAllFields(JSONLD_HTML, null);
+  assert.equal(fields.title?.value, 'Senate passes "landmark" climate bill after all-night session');
+  assert.equal(fields.title?.source, "json-ld");
+});
+
+test("JSON-LD author array of Person objects joins names", () => {
+  const fields = extractAllFields(JSONLD_HTML, null);
+  assert.equal(fields.author?.value, "Maria Chen, Tom Walsh");
+});
+
+test("JSON-LD publisher and image extract", () => {
+  const fields = extractAllFields(JSONLD_HTML, null);
+  assert.equal(fields.publication?.value, "The Gazette");
+  assert.equal(fields.thumbnail?.value, "https://gazette.example/img/climate.jpg");
+});
+
+test("malformed JSON-LD block is skipped without breaking other layers", () => {
+  const html = `<html><head>
+    <script type="application/ld+json">{ "truncated": "mid-doc`
+    + `</script>
+    <meta property="og:title" content="Fallback title works here">
+    </head><body></body></html>`;
+  const fields = extractAllFields(html, null);
+  assert.equal(fields.title?.value, "Fallback title works here");
+});
+
+// ─── Fixture 3: body text in a container with nested divs ───────────
+// The old regex `<div[^>]*class="article-body"...>([\s\S]*?)</div>`
+// stopped at the FIRST closing </div> — the inner ad wrapper — and
+// returned a fragment.
+
+const para = (i: number) =>
+  `<p>Paragraph ${i} of the story continues with enough text to clear the minimum length filter for extraction.</p>`;
+
+const NESTED_BODY_HTML = `<!DOCTYPE html><html><head><title>Story</title></head><body>
+<nav><p>Home News Sports Opinion Weather Subscribe Today For Less Than One Dollar Per Week</p></nav>
+<div class="article-body">
+  ${para(1)}
+  <div class="inline-ad"><span>Advertisement</span></div>
+  ${para(2)}
+  <div class="photo-wrapper"><div class="caption">A photo caption here</div></div>
+  ${para(3)}
+  ${para(4)}
+</div>
+<footer><p>Copyright 2026 The Gazette. All rights reserved. Terms of service and privacy policy apply.</p></footer>
+</body></html>`;
+
+test("body extraction captures paragraphs past nested closing divs", () => {
+  const body = extractBodyText(NESTED_BODY_HTML, null);
+  assert.ok(body, "body should be extracted");
+  for (const i of [1, 2, 3, 4]) {
+    assert.ok(body!.includes(`Paragraph ${i}`), `missing paragraph ${i}`);
+  }
+});
+
+test("body extraction excludes nav and footer noise", () => {
+  const body = extractBodyText(NESTED_BODY_HTML, null);
+  assert.ok(!body!.includes("Subscribe Today"), "nav text leaked into body");
+  assert.ok(!body!.includes("All rights reserved"), "footer text leaked into body");
+});
+
+// ─── Fixture 4: site-registry CSS selectors ──────────────────────────
+// Recipes carry per-site selectors that the old route ignored entirely.
+
+const RECIPE = {
+  selectors: {
+    title: { css: "h1[data-testid='Heading']", attr: null, fallback: "og:title" },
+    author: { css: "a[data-testid='AuthorName']", attr: null, multi: true, separator: ", " },
+    publishDate: { css: "time[data-testid='Published']", attr: "datetime" },
+    body: { css: "[data-testid='paragraph']" },
+  },
+} as Record<string, unknown>;
+
+const RECIPE_HTML = `<!DOCTYPE html><html><head>
+<meta property="og:title" content="Wrong title from stale OG tag">
+</head><body>
+<h1 data-testid="Heading">Exclusive: Regulators open inquiry into data broker</h1>
+<a data-testid="AuthorName">Priya Patel</a>
+<a data-testid="AuthorName">Lee Nakamura</a>
+<time data-testid="Published" datetime="2026-05-30T12:00:00Z">May 30</time>
+<div data-testid="paragraph">The inquiry was opened after a complaint alleging unauthorized resale of location data.</div>
+<div data-testid="paragraph">The company denied wrongdoing in a statement released Friday afternoon to investors.</div>
+</body></html>`;
+
+test("recipe CSS selectors take priority over meta tags", () => {
+  const fields = extractAllFields(RECIPE_HTML, RECIPE);
+  assert.equal(fields.title?.value, "Exclusive: Regulators open inquiry into data broker");
+  assert.equal(fields.title?.source, "recipe");
+});
+
+test("recipe multi-selector joins authors", () => {
+  const fields = extractAllFields(RECIPE_HTML, RECIPE);
+  assert.equal(fields.author?.value, "Priya Patel, Lee Nakamura");
+});
+
+test("recipe attr selector reads datetime attribute", () => {
+  const fields = extractAllFields(RECIPE_HTML, RECIPE);
+  assert.equal(fields.publishDate?.value, "2026-05-30T12:00:00Z");
+});
+
+test("recipe body selector collects paragraph elements", () => {
+  const body = extractBodyText(RECIPE_HTML, RECIPE);
+  assert.ok(body!.includes("unauthorized resale of location data"));
+  assert.ok(body!.includes("denied wrongdoing"));
+});
+
+test("invalid recipe selector falls back gracefully", () => {
+  const badRecipe = { selectors: { title: { css: "h1[[[" } } } as Record<string, unknown>;
+  const fields = extractAllFields(APOSTROPHE_HTML, badRecipe);
+  assert.equal(fields.title?.value, "Trump's plan sparks debate over 'emergency' powers");
+});
+
+// ─── Fixture 5: HTML entities and fallbacks ─────────────────────────
+
+test("named HTML entities decode in meta content", () => {
+  const html = `<html><head>
+    <meta property="og:title" content="It&rsquo;s official &mdash; the merger is dead&hellip;">
+    </head><body></body></html>`;
+  const fields = extractAllFields(html, null);
+  assert.equal(fields.title?.value, "It’s official — the merger is dead…");
+});
+
+test("falls back to <title> then <h1> when no meta tags exist", () => {
+  const html = `<html><head><title>Council votes to expand transit service | Metro News</title></head>
+    <body><h1>Council votes to expand transit service</h1></body></html>`;
+  const fields = extractAllFields(html, null);
+  assert.equal(fields.title?.value, "Council votes to expand transit service");
+});
+
+test("canonical URL extracted from link tag", () => {
+  const html = `<html><head>
+    <link rel="canonical" href="https://example.com/story/canonical-path">
+    <meta property="og:title" content="A story title goes here">
+    </head><body></body></html>`;
+  const fields = extractAllFields(html, null);
+  assert.equal(fields._canonical?.value, "https://example.com/story/canonical-path");
+});
+
+// ─── Fixture 6: paragraph fallback when no known container exists ───
+
+test("falls back to page-wide paragraphs when no container matches", () => {
+  const html = `<html><body>
+    <div class="weird-custom-wrapper">
+      ${para(1)} ${para(2)} ${para(3)}
+    </div>
+  </body></html>`;
+  const body = extractBodyText(html, null);
+  assert.ok(body!.includes("Paragraph 1"));
+  assert.ok(body!.includes("Paragraph 3"));
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,


### PR DESCRIPTION
…ilures

The submit form's import service used hand-rolled regex extraction that failed on most real-world pages:

- Meta regex content=["']([^"']+)["'] truncated values at the first quote of either kind, so any headline with an apostrophe imported as garbage ("Trump's plan..." became "Trump")
- JSON-LD layer compared @type arrays against a string list, so outlets emitting "@type": ["NewsArticle"] (NYT, Guardian, WaPo) never matched the highest-quality extraction layer
- 200KB fetch cap truncated modern news pages mid-document, breaking JSON-LD parsing and body extraction
- Body container regex stopped at the first nested closing tag, capturing a fragment instead of the article
- The site registry's per-site CSS selectors were ignored entirely

New src/lib/import/extract.ts (cheerio, already a dependency):
- Honors site-registry CSS selector recipes (css/attr/multi/fallback)
- JSON-LD handles @graph containers, @type arrays, author objects
- 1.5MB fetch cap with charset detection (header + meta sniffing)
- 403/429 responses retried once with an identified-crawler UA
- Body extraction scores candidate containers by paragraph mass instead of taking the first regex match

The submit form now surfaces the real fetch error (e.g. site blocked the request) instead of "No content found on page."

Adds offline fixture tests: node --experimental-strip-types tests/import-extract.test.ts

https://claude.ai/code/session_01PucAFAES3Qae71qd4Lo2ZR