### PR TITLE
Fix import on live-updates pages: scoped bylines, capped authors, liv…

### DIFF
--- a/spa/lib/platforms.js
+++ b/spa/lib/platforms.js
@@ -12,7 +12,7 @@ export const PLATFORMS = {
     headlineLabel: "ORIGINAL HEADLINE *",
     headlineMultiline: false,
     subtitleLabel: "SUBTITLE (OPTIONAL)",
-    authorLabel: "AUTHOR(S) (OPTIONAL)",
+    authorLabel: "AUTHOR(S)",
     authorPlaceholder: "Type author name and press Enter",
     section2Title: "REWRITE THE HEADLINE",
     replacementLabel: "PROPOSED REPLACEMENT *",

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -4,6 +4,7 @@ import {
   fetchHtml,
   extractAllFields,
   extractBodyText,
+  normalizeAuthors,
   type Fields,
   type FieldResult,
 } from "@/lib/import/extract";
@@ -174,6 +175,14 @@ async function importUrl(rawUrl: string): Promise<ImportResult> {
 
   // Apply site-specific hints (title stripping, etc.)
   applyMetaHints(fields, recipe);
+
+  // Normalize the byline: strip "By", drop publication suffix, cap count
+  if (fields.author?.value) {
+    const siteName = fields.publication?.value || fields.siteName?.value;
+    const normalized = normalizeAuthors(fields.author.value, siteName);
+    if (normalized) fields.author.value = normalized;
+    else delete fields.author;
+  }
 
   // Extract canonical URL
   const canonical = fields._canonical?.value || normalizedUrl;

--- a/src/lib/import/extract.ts
+++ b/src/lib/import/extract.ts
@@ -146,8 +146,21 @@ function extractWithSelector($: CheerioAPI, rule: SelectorRule): string | null {
     (rule.attr ? el.attr(rule.attr) : el.text())?.trim() || null;
 
   if (rule.multi) {
+    // Scope multi-matches to the first match's byline cluster. Live-blog
+    // pages and "related story" teasers repeat byline elements all over
+    // the page — without scoping, a CNN live-updates page yields 20+
+    // authors. On a normal article all authors share one byline block,
+    // so scoping keeps them all.
+    let scoped = elements;
+    const cluster = elements.first().parent().closest(
+      '[class*="byline"], [class*="metadata"], [class*="author"], header, article'
+    );
+    if (cluster.length > 0) {
+      const within = cluster.find(rule.css);
+      if (within.length > 0) scoped = within;
+    }
     const values: string[] = [];
-    elements.each((_, el) => {
+    scoped.each((_, el) => {
       const v = readOne($(el));
       if (v && !values.includes(v)) values.push(v);
     });
@@ -231,6 +244,23 @@ export function extractJsonLd($: CheerioAPI): Fields {
     }
 
     for (const item of items) {
+      // Live blogs: the real content lives in liveBlogUpdate entries.
+      // Assemble their headlines and bodies; do NOT collect per-update
+      // authors — live pages credit 20+ contributors across updates.
+      if (Array.isArray(item.liveBlogUpdate) && !fields.body) {
+        const sections: string[] = [];
+        for (const update of item.liveBlogUpdate as Record<string, unknown>[]) {
+          if (!update || typeof update !== "object") continue;
+          const headline = typeof update.headline === "string" ? update.headline.trim() : "";
+          const body = typeof update.articleBody === "string" ? update.articleBody.trim() : "";
+          if (headline && body) sections.push(`${headline}\n\n${body}`);
+          else if (body) sections.push(body);
+          else if (headline) sections.push(headline);
+        }
+        if (sections.length > 0) {
+          fields.body = { value: sections.join("\n\n").slice(0, 10000), source: "json-ld-liveblog", confidence: 0.85 };
+        }
+      }
       if (typeMatches(item["@type"], ARTICLE_TYPES)) {
         setOnce("title", item.headline || item.name, 0.9);
         setOnce("description", item.description, 0.85);
@@ -420,6 +450,29 @@ export function extractBodyText(html: string, recipe: Record<string, unknown> | 
     if (bestScore > 1500) break; // strong match — no need to scan weaker selectors
   }
 
+  // Live blogs render each update as its own <article>. If several
+  // substantial articles exist, the story is their concatenation in
+  // DOM order — not the single longest update.
+  const articles = $("article");
+  if (articles.length >= 2) {
+    const seen = new Set<string>();
+    const combined: string[] = [];
+    let combinedScore = 0;
+    articles.each((_, el) => {
+      if ($(el).parents("article").length > 0) return; // skip nested articles
+      const paragraphs = paragraphsFrom($, $(el));
+      const score = paragraphs.reduce((sum, p) => sum + p.length, 0);
+      if (score < 150) return; // teaser/related-story stubs
+      for (const p of paragraphs) {
+        if (!seen.has(p)) { seen.add(p); combined.push(p); combinedScore += p.length; }
+      }
+    });
+    if (combinedScore > bestScore) {
+      bestScore = combinedScore;
+      bestParagraphs = combined;
+    }
+  }
+
   if (bestScore < 200) {
     // Last resort: every <p> on the page
     const all = paragraphsFrom($, $("body"));
@@ -429,6 +482,29 @@ export function extractBodyText(html: string, recipe: Record<string, unknown> | 
 
   if (bestParagraphs.length === 0) return null;
   return bestParagraphs.join("\n\n").slice(0, MAX_BODY_CHARS);
+}
+
+// ─── Author normalization ──────────────────────────────────────────
+
+// Bylines arrive as "By Jane O'Brien, Sam D'Angelo and Lee Park, CNN".
+// Strip the "By", drop a trailing publication name, dedupe, and cap —
+// live pages can credit 20+ contributors, which is unusable as form chips.
+const MAX_AUTHORS = 6;
+
+export function normalizeAuthors(raw: string, siteName?: string): string {
+  const stripped = raw.trim().replace(/^by\s+/i, "");
+  const parts = stripped.split(/\s*,\s*|\s+and\s+/i).map((p) => p.trim()).filter(Boolean);
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (siteName && lower === siteName.toLowerCase()) continue;
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    names.push(part);
+    if (names.length >= MAX_AUTHORS) break;
+  }
+  return names.join(", ");
 }
 
 // ─── Combined extraction ───────────────────────────────────────────

--- a/tests/import-extract.test.ts
+++ b/tests/import-extract.test.ts
@@ -231,5 +231,105 @@ test("falls back to page-wide paragraphs when no container matches", () => {
   assert.ok(body!.includes("Paragraph 3"));
 });
 
+// ─── Fixture 7: live-updates pages (CNN-style) ──────────────────────
+// Live blogs repeat byline elements in every update post and in
+// "related story" teasers. A multi:true recipe selector must scope to
+// the page-level byline block, not vacuum the whole page. Body text
+// lives across many <article> posts (or in JSON-LD liveBlogUpdate).
+
+import { normalizeAuthors } from "../src/lib/import/extract.ts";
+
+const CNN_RECIPE = {
+  selectors: {
+    title: { css: "h1.headline__text", attr: null, fallback: "og:title" },
+    author: { css: ".byline__name", attr: null, multi: true, separator: ", " },
+    body: { css: ".article__content p, .zn-body__paragraph" },
+  },
+} as Record<string, unknown>;
+
+const livePost = (i: number, author: string) => `
+<article class="live-story-post">
+  <header><h2>Update ${i}: strikes reported near the border</h2>
+  <div class="byline"><span class="byline__name">${author}</span></div></header>
+  <div class="live-story-post__content">
+    <p>Update ${i} body paragraph one with enough words to pass the extraction length filter comfortably.</p>
+    <p>Update ${i} body paragraph two describing further developments reported by correspondents on the ground.</p>
+  </div>
+</article>`;
+
+const LIVE_PAGE_HTML = `<!DOCTYPE html><html><head>
+<meta property="og:title" content="Live updates: US military launches strikes | CNN">
+</head><body>
+<h1 class="headline__text">Live updates: US military launches strikes</h1>
+<div class="headline__byline">
+  <div class="byline__names">
+    <span class="byline__name">Davis Winkie</span>
+    <span class="byline__name">Alayna Treene</span>
+    <span class="byline__name">Kit Maher</span>
+  </div>
+</div>
+${livePost(1, "Jeremy Diamond")}
+${livePost(2, "Zachary Cohen")}
+${livePost(3, "Haley Britzky")}
+<div class="related-content">
+  <article class="card"><h3>Analysis: what comes next</h3>
+  <span class="byline__name">Aaron Blake</span></article>
+  <article class="card"><h3>Markets react to the news</h3>
+  <span class="byline__name">Matt Egan</span></article>
+</div>
+</body></html>`;
+
+test("live page: multi-selector scopes to page-level byline block", () => {
+  const fields = extractAllFields(LIVE_PAGE_HTML, CNN_RECIPE);
+  assert.equal(fields.author?.value, "Davis Winkie, Alayna Treene, Kit Maher");
+});
+
+test("live page: body concatenates update posts, skips teaser stubs", () => {
+  const body = extractBodyText(LIVE_PAGE_HTML, CNN_RECIPE);
+  assert.ok(body, "body should be extracted");
+  for (const i of [1, 2, 3]) {
+    assert.ok(body!.includes(`Update ${i} body paragraph one`), `missing update ${i}`);
+  }
+  assert.ok(!body!.includes("Markets react"), "related-story teaser leaked into body");
+});
+
+test("JSON-LD liveBlogUpdate assembles body without collecting update authors", () => {
+  const html = `<html><head><script type="application/ld+json">
+  {
+    "@type": "LiveBlogPosting",
+    "headline": "Live updates: severe weather across the plains",
+    "author": { "@type": "Organization", "name": "The Gazette" },
+    "liveBlogUpdate": [
+      { "@type": "BlogPosting", "headline": "Tornado warning issued", "articleBody": "The national weather service issued a warning for three counties.", "author": { "name": "Contributor One" } },
+      { "@type": "BlogPosting", "headline": "Power outages spread", "articleBody": "Utilities reported forty thousand customers without electricity.", "author": { "name": "Contributor Two" } }
+    ]
+  }
+  </script></head><body></body></html>`;
+  const fields = extractAllFields(html, null);
+  assert.equal(fields.title?.value, "Live updates: severe weather across the plains");
+  assert.ok(fields.body?.value.includes("Tornado warning issued"));
+  assert.ok(fields.body?.value.includes("forty thousand customers"));
+  assert.equal(fields.author?.value, "The Gazette");
+});
+
+// ─── Fixture 8: author normalization ────────────────────────────────
+
+test("normalizeAuthors strips 'By', publication suffix, and 'and'", () => {
+  assert.equal(
+    normalizeAuthors("By Kevin Liptak, Alayna Treene and Kit Maher, CNN", "CNN"),
+    "Kevin Liptak, Alayna Treene, Kit Maher"
+  );
+});
+
+test("normalizeAuthors caps runaway contributor lists", () => {
+  const twentyFour = Array.from({ length: 24 }, (_, i) => `Reporter ${i + 1}`).join(", ");
+  const result = normalizeAuthors(twentyFour);
+  assert.equal(result.split(", ").length, 6);
+});
+
+test("normalizeAuthors dedupes repeated names", () => {
+  assert.equal(normalizeAuthors("Jane Doe, jane doe, Jane Doe"), "Jane Doe");
+});
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
…e-blog body

Testing on a CNN live-updates page surfaced two bugs:

- Author over-collection: live pages repeat byline elements in every update post and related-story teaser, so the registry's multi:true author selector (and CNN's page-wide contributor meta) produced 20+ author chips. Multi-selectors now scope to the first match's byline cluster, and the route normalizes bylines: strip "By", drop a trailing publication name, dedupe, cap at 6.

- Missing article text: live-blog content wasn't extracted. The JSON-LD layer now assembles body text from liveBlogUpdate entries (headline + articleBody per update, without collecting per-update authors), and the DOM body extractor concatenates multiple substantial <article> posts in page order instead of keeping only the single highest-scoring one.

Also fixes the doubled "AUTHOR(S) (OPTIONAL) (OPTIONAL)" label — platforms.js carried "(OPTIONAL)" in a label the form already suffixes with "(optional)".

Adds live-page fixtures to tests/import-extract.test.ts (24 tests).

https://claude.ai/code/session_01PucAFAES3Qae71qd4Lo2ZR